### PR TITLE
Add preflight command to validate environment

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,6 +62,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.101"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
+
+[[package]]
 name = "assert_cmd"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -83,6 +89,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "bitflags"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+
+[[package]]
 name = "bstr"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -92,6 +104,12 @@ dependencies = [
  "regex-automata",
  "serde",
 ]
+
+[[package]]
+name = "cfg-if"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "clap"
@@ -146,6 +164,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
 
 [[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
 name = "float-cmp"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -155,10 +195,62 @@ dependencies = [
 ]
 
 [[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "getrandom"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139ef39800118c7683f2fd3c98c1b23c09ae076556b435f8e9064ae108aaeeec"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+ "wasip3",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "indexmap"
+version = "2.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.16.1",
+ "serde",
+ "serde_core",
+]
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -167,10 +259,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
+name = "itoa"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+
+[[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
 name = "libc"
 version = "0.2.181"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "459427e2af2b9c839b132acb702a1c654d95e10f8c326bfc2ad11310e458b1c5"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+
+[[package]]
+name = "log"
+version = "0.4.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "memchr"
@@ -192,6 +308,12 @@ checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
 ]
+
+[[package]]
+name = "once_cell"
+version = "1.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "once_cell_polyfill"
@@ -230,6 +352,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -246,6 +378,12 @@ checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "regex"
@@ -277,6 +415,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
 
 [[package]]
+name = "rustix"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
+name = "semver"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+
+[[package]]
 name = "serde"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -306,12 +463,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_json"
+version = "1.0.149"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
 name = "stck"
 version = "0.1.0"
 dependencies = [
  "assert_cmd",
  "clap",
  "predicates",
+ "tempfile",
 ]
 
 [[package]]
@@ -332,6 +503,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0136791f7c95b1f6dd99f9cc786b91bb81c3800b639b3478e561ddb7be95e5f1"
+dependencies = [
+ "fastrand",
+ "getrandom",
+ "once_cell",
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
 name = "termtree"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -342,6 +526,12 @@ name = "unicode-ident"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "537dd038a89878be9b64dd4bd1b260315c1bb94f4d784956b81e27a088d9a09e"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "utf8parse"
@@ -359,6 +549,58 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasip2"
+version = "1.0.2+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -372,3 +614,97 @@ checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
+
+[[package]]
+name = "zmij"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4de98dfa5d5b7fef4ee834d0073d560c9ca7b6c46a71d058c48db7960f8cfaf7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,4 @@ clap = { version = "4.5.30", features = ["derive"] }
 [dev-dependencies]
 assert_cmd = "2.0.16"
 predicates = "3.1.3"
+tempfile = "3.14.0"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,6 +1,8 @@
 use clap::{Parser, Subcommand};
 use std::process::ExitCode;
 
+use crate::env;
+
 #[derive(Debug, Parser)]
 #[command(
     name = "stck",
@@ -35,6 +37,15 @@ pub fn run() -> ExitCode {
         Commands::Sync => "sync",
         Commands::Push => "push",
     };
+
+    let preflight = match env::run_preflight() {
+        Ok(preflight) => preflight,
+        Err(message) => {
+            eprintln!("error: {message}");
+            return ExitCode::from(1);
+        }
+    };
+    let _ = preflight.default_branch;
 
     eprintln!("error: `stck {command}` is not implemented yet");
     ExitCode::from(1)

--- a/src/env.rs
+++ b/src/env.rs
@@ -1,0 +1,136 @@
+use std::process::Command;
+
+#[derive(Debug, Clone)]
+pub struct PreflightContext {
+    pub default_branch: String,
+}
+
+pub fn run_preflight() -> Result<PreflightContext, String> {
+    ensure_command_available("git")?;
+    ensure_command_available("gh")?;
+    ensure_gh_auth()?;
+    ensure_origin_remote()?;
+    ensure_on_branch()?;
+    ensure_clean_working_tree()?;
+    let default_branch = discover_default_branch()?;
+
+    Ok(PreflightContext { default_branch })
+}
+
+fn ensure_command_available(command: &str) -> Result<(), String> {
+    let output = Command::new(command)
+        .arg("--version")
+        .output()
+        .map_err(|_| {
+            format!("required command `{command}` was not found in PATH; install it and retry")
+        })?;
+
+    if output.status.success() {
+        Ok(())
+    } else {
+        Err(format!(
+            "failed to execute `{command} --version`; ensure `{command}` is installed and runnable"
+        ))
+    }
+}
+
+fn ensure_gh_auth() -> Result<(), String> {
+    let output = Command::new("gh")
+        .args(["auth", "status"])
+        .output()
+        .map_err(|_| {
+            "failed to run `gh auth status`; install GitHub CLI and authenticate".to_string()
+        })?;
+
+    if output.status.success() {
+        Ok(())
+    } else {
+        Err("GitHub CLI is not authenticated; run `gh auth login` and retry".to_string())
+    }
+}
+
+fn ensure_origin_remote() -> Result<(), String> {
+    let output = Command::new("git")
+        .args(["remote", "get-url", "origin"])
+        .output()
+        .map_err(|_| {
+            "failed to run `git remote get-url origin`; ensure this is a git repository".to_string()
+        })?;
+
+    if output.status.success() {
+        Ok(())
+    } else {
+        Err("`origin` remote is missing; add it with `git remote add origin <url>`".to_string())
+    }
+}
+
+fn ensure_on_branch() -> Result<(), String> {
+    let output = Command::new("git")
+        .args(["symbolic-ref", "--quiet", "--short", "HEAD"])
+        .output()
+        .map_err(|_| {
+            "failed to determine current branch; ensure this is a git repository".to_string()
+        })?;
+
+    if output.status.success() {
+        Ok(())
+    } else {
+        Err("not on a branch (detached HEAD); checkout a branch and retry".to_string())
+    }
+}
+
+fn ensure_clean_working_tree() -> Result<(), String> {
+    let output = Command::new("git")
+        .args(["status", "--porcelain"])
+        .output()
+        .map_err(|_| {
+            "failed to inspect working tree; ensure this is a git repository".to_string()
+        })?;
+
+    if !output.status.success() {
+        return Err(
+            "failed to check working tree status; ensure this is a git repository".to_string(),
+        );
+    }
+
+    let is_clean = output.stdout.is_empty();
+    if is_clean {
+        Ok(())
+    } else {
+        Err(
+            "working tree is not clean; commit, stash, or discard changes before running stck"
+                .to_string(),
+        )
+    }
+}
+
+fn discover_default_branch() -> Result<String, String> {
+    let output = Command::new("gh")
+        .args([
+            "repo",
+            "view",
+            "--json",
+            "defaultBranchRef",
+            "--jq",
+            ".defaultBranchRef.name",
+        ])
+        .output()
+        .map_err(|_| "failed to discover repository default branch from GitHub".to_string())?;
+
+    if !output.status.success() {
+        return Err(
+            "could not discover default branch via GitHub CLI; ensure `origin` points to GitHub and `gh auth status` succeeds"
+                .to_string(),
+        );
+    }
+
+    let branch = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if branch.is_empty() {
+        Err(
+            "default branch lookup returned empty result; verify repository metadata on GitHub"
+                .to_string(),
+        )
+    } else {
+        Ok(branch)
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 mod cli;
+mod env;
 
 use std::process::ExitCode;
 

--- a/tests/cli_skeleton.rs
+++ b/tests/cli_skeleton.rs
@@ -1,13 +1,110 @@
 use assert_cmd::cargo::cargo_bin_cmd;
 use assert_cmd::Command;
 use predicates::prelude::*;
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::Path;
+use tempfile::TempDir;
 
 fn stck_cmd() -> Command {
     cargo_bin_cmd!("stck")
 }
 
+fn write_stub(path: &Path, body: &str) {
+    fs::write(path, body).expect("stub script should be written");
+    let mut permissions = fs::metadata(path)
+        .expect("stub metadata should be readable")
+        .permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(path, permissions).expect("stub script should be executable");
+}
+
+fn setup_stubbed_tools() -> TempDir {
+    let temp = TempDir::new().expect("tempdir should be created");
+    let bin_dir = temp.path().join("bin");
+    fs::create_dir_all(&bin_dir).expect("bin dir should be created");
+
+    write_stub(
+        &bin_dir.join("git"),
+        r#"#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "${1:-}" == "--version" ]]; then
+  echo "git version 2.0.0"
+  exit 0
+fi
+
+if [[ "${1:-}" == "remote" && "${2:-}" == "get-url" && "${3:-}" == "origin" ]]; then
+  if [[ "${STCK_TEST_ORIGIN_MISSING:-0}" == "1" ]]; then
+    exit 2
+  fi
+  echo "git@github.com:example/stck.git"
+  exit 0
+fi
+
+if [[ "${1:-}" == "symbolic-ref" && "${2:-}" == "--quiet" && "${3:-}" == "--short" && "${4:-}" == "HEAD" ]]; then
+  if [[ "${STCK_TEST_DETACHED_HEAD:-0}" == "1" ]]; then
+    exit 1
+  fi
+  echo "feature-branch"
+  exit 0
+fi
+
+if [[ "${1:-}" == "status" && "${2:-}" == "--porcelain" ]]; then
+  if [[ "${STCK_TEST_DIRTY_TREE:-0}" == "1" ]]; then
+    echo " M src/main.rs"
+  fi
+  exit 0
+fi
+
+exit 0
+"#,
+    );
+
+    write_stub(
+        &bin_dir.join("gh"),
+        r#"#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "${1:-}" == "--version" ]]; then
+  echo "gh version 2.0.0"
+  exit 0
+fi
+
+if [[ "${1:-}" == "auth" && "${2:-}" == "status" ]]; then
+  if [[ "${STCK_TEST_GH_AUTH_FAIL:-0}" == "1" ]]; then
+    exit 1
+  fi
+  exit 0
+fi
+
+if [[ "${1:-}" == "repo" && "${2:-}" == "view" ]]; then
+  if [[ "${STCK_TEST_DEFAULT_BRANCH_FAIL:-0}" == "1" ]]; then
+    exit 1
+  fi
+  echo "main"
+  exit 0
+fi
+
+exit 0
+"#,
+    );
+
+    temp
+}
+
+fn stck_cmd_with_stubbed_tools() -> (TempDir, Command) {
+    let temp = setup_stubbed_tools();
+    let path = std::env::var("PATH").expect("PATH should be set");
+    let full_path = format!("{}:{}", temp.path().join("bin").display(), path);
+
+    let mut cmd = stck_cmd();
+    cmd.env("PATH", full_path);
+    (temp, cmd)
+}
+
 #[test]
-fn help_lists_all_milestone_zero_commands() {
+fn help_lists_all_commands() {
     let mut cmd = stck_cmd();
     cmd.arg("--help");
 
@@ -20,41 +117,63 @@ fn help_lists_all_milestone_zero_commands() {
 }
 
 #[test]
-fn new_placeholder_is_clear() {
-    let mut cmd = stck_cmd();
-    cmd.args(["new", "feature-x"]);
+fn commands_show_placeholder_when_preflight_passes() {
+    for command in ["new", "status", "sync", "push"] {
+        let (_temp, mut cmd) = stck_cmd_with_stubbed_tools();
+        if command == "new" {
+            cmd.args([command, "feature-x"]);
+        } else {
+            cmd.arg(command);
+        }
 
-    cmd.assert().code(1).stderr(predicate::str::contains(
-        "error: `stck new` is not implemented yet",
-    ));
+        cmd.assert()
+            .code(1)
+            .stderr(predicate::str::contains(format!(
+                "error: `stck {command}` is not implemented yet"
+            )));
+    }
 }
 
 #[test]
-fn status_placeholder_is_clear() {
-    let mut cmd = stck_cmd();
+fn shows_auth_remediation_when_gh_is_not_authenticated() {
+    let (_temp, mut cmd) = stck_cmd_with_stubbed_tools();
+    cmd.env("STCK_TEST_GH_AUTH_FAIL", "1");
     cmd.arg("status");
 
     cmd.assert().code(1).stderr(predicate::str::contains(
-        "error: `stck status` is not implemented yet",
+        "error: GitHub CLI is not authenticated; run `gh auth login` and retry",
     ));
 }
 
 #[test]
-fn sync_placeholder_is_clear() {
-    let mut cmd = stck_cmd();
+fn shows_dirty_tree_remediation() {
+    let (_temp, mut cmd) = stck_cmd_with_stubbed_tools();
+    cmd.env("STCK_TEST_DIRTY_TREE", "1");
     cmd.arg("sync");
 
     cmd.assert().code(1).stderr(predicate::str::contains(
-        "error: `stck sync` is not implemented yet",
+        "error: working tree is not clean; commit, stash, or discard changes before running stck",
     ));
 }
 
 #[test]
-fn push_placeholder_is_clear() {
-    let mut cmd = stck_cmd();
+fn shows_missing_origin_remediation() {
+    let (_temp, mut cmd) = stck_cmd_with_stubbed_tools();
+    cmd.env("STCK_TEST_ORIGIN_MISSING", "1");
+    cmd.arg("status");
+
+    cmd.assert().code(1).stderr(predicate::str::contains(
+        "error: `origin` remote is missing; add it with `git remote add origin <url>`",
+    ));
+}
+
+#[test]
+fn shows_detached_head_remediation() {
+    let (_temp, mut cmd) = stck_cmd_with_stubbed_tools();
+    cmd.env("STCK_TEST_DETACHED_HEAD", "1");
     cmd.arg("push");
 
     cmd.assert().code(1).stderr(predicate::str::contains(
-        "error: `stck push` is not implemented yet",
+        "error: not on a branch (detached HEAD); checkout a branch and retry",
     ));
 }


### PR DESCRIPTION
## Milestone 1: Environment + Repo Preflight

### What changed
- Added shared preflight checks and wired them into all commands (`new`, `status`, `sync`, `push`).
- New checks cover:
  - `git` and `gh` availability
  - `gh auth status`
  - `origin` remote presence
  - branch state (not detached HEAD)
  - clean working tree
  - default branch discovery from GitHub metadata
- Added integration tests with stubbed `git`/`gh` to validate:
  - successful preflight path (still reaches current placeholder behavior)
  - actionable error paths (`gh` unauthenticated, dirty tree, missing `origin`, detached HEAD)

### Why
- Establishes a strict shared preflight foundation required before implementing command logic in later milestones.
- Ensures failures are predictable and user-fixable with clear remediation messaging.

### Validation
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features`
- `cargo build --all-features`
