### PR TITLE
Add PR discovery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -440,6 +440,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
+ "serde_derive",
 ]
 
 [[package]]
@@ -482,6 +483,8 @@ dependencies = [
  "assert_cmd",
  "clap",
  "predicates",
+ "serde",
+ "serde_json",
  "tempfile",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,8 @@ edition = "2021"
 
 [dependencies]
 clap = { version = "4.5.30", features = ["derive"] }
+serde = { version = "1.0.218", features = ["derive"] }
+serde_json = "1.0.139"
 
 [dev-dependencies]
 assert_cmd = "2.0.16"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2,6 +2,7 @@ use clap::{Parser, Subcommand};
 use std::process::ExitCode;
 
 use crate::env;
+use crate::github;
 
 #[derive(Debug, Parser)]
 #[command(
@@ -31,13 +32,6 @@ enum Commands {
 pub fn run() -> ExitCode {
     let cli = Cli::parse();
 
-    let command = match cli.command {
-        Commands::New { .. } => "new",
-        Commands::Status => "status",
-        Commands::Sync => "sync",
-        Commands::Push => "push",
-    };
-
     let preflight = match env::run_preflight() {
         Ok(preflight) => preflight,
         Err(message) => {
@@ -47,6 +41,34 @@ pub fn run() -> ExitCode {
     };
     let _ = preflight.default_branch;
 
-    eprintln!("error: `stck {command}` is not implemented yet");
-    ExitCode::from(1)
+    match cli.command {
+        Commands::Status => {
+            let pr = match github::pr_for_head(&preflight.current_branch) {
+                Ok(pr) => pr,
+                Err(message) => {
+                    eprintln!("error: {message}");
+                    return ExitCode::from(1);
+                }
+            };
+
+            let _ = pr.merged_at;
+            println!(
+                "PR #{} state={} base={} head={}",
+                pr.number, pr.state, pr.base_ref_name, pr.head_ref_name
+            );
+            ExitCode::SUCCESS
+        }
+        Commands::New { .. } => {
+            eprintln!("error: `stck new` is not implemented yet");
+            ExitCode::from(1)
+        }
+        Commands::Sync => {
+            eprintln!("error: `stck sync` is not implemented yet");
+            ExitCode::from(1)
+        }
+        Commands::Push => {
+            eprintln!("error: `stck push` is not implemented yet");
+            ExitCode::from(1)
+        }
+    }
 }

--- a/src/github.rs
+++ b/src/github.rs
@@ -1,0 +1,37 @@
+use serde::Deserialize;
+use std::process::Command;
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct PullRequest {
+    pub number: u64,
+    #[serde(rename = "headRefName")]
+    pub head_ref_name: String,
+    #[serde(rename = "baseRefName")]
+    pub base_ref_name: String,
+    pub state: String,
+    #[serde(rename = "mergedAt")]
+    pub merged_at: Option<String>,
+}
+
+pub fn pr_for_head(branch: &str) -> Result<PullRequest, String> {
+    let output = Command::new("gh")
+        .args([
+            "pr",
+            "view",
+            branch,
+            "--json",
+            "number,headRefName,baseRefName,state,mergedAt",
+        ])
+        .output()
+        .map_err(|_| "failed to run `gh pr view`; ensure GitHub CLI is installed".to_string())?;
+
+    if !output.status.success() {
+        return Err(format!(
+            "no PR found for branch {branch}; create a PR first"
+        ));
+    }
+
+    serde_json::from_slice::<PullRequest>(&output.stdout).map_err(|_| {
+        format!("failed to parse PR metadata for branch {branch} from GitHub CLI output")
+    })
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 mod cli;
 mod env;
+mod github;
 
 use std::process::ExitCode;
 


### PR DESCRIPTION
## Summary

Implement Milestone 2 by adding single-PR discovery for the current branch via GitHub CLI and surfacing it in `stck status`.

This introduces a dedicated GitHub module that shells out to `gh pr view <branch> --json ...`, parses typed PR metadata, and keeps error handling user-facing. It also extends preflight context to expose the current branch and updates integration tests to cover both successful PR discovery and missing-PR remediation.

## Changelist

- `src/github.rs`: add `pr_for_head(branch)` and typed PR JSON parsing (`number`, `headRefName`, `baseRefName`, `state`, `mergedAt`)
- `src/cli.rs`: wire `status` to call PR discovery and print parsed PR metadata
- `src/env.rs`: include `current_branch` in preflight context for downstream command use
- `src/main.rs`: register new `github` module
- `tests/cli_skeleton.rs`: add status success/missing-PR tests and extend gh stubs for `pr view`
- `Cargo.toml`: add `serde` and `serde_json` dependencies
- `Cargo.lock`: lockfile updates for new dependencies

## Checklist

- [x] Changes are minimal and focused for this milestone
- [x] No breaking CLI changes unless explicitly intended
- [x] Errors are user-facing, actionable, and prefixed with `error:`
- [x] Added/updated tests for behavior changes
- [ ] Updated docs/plan if behavior or scope changed
