### PR TITLE
Add --version support

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -10,7 +10,8 @@ use crate::sync_state::{self, PushState, SyncState};
 #[derive(Debug, Parser)]
 #[command(
     name = "stck",
-    about = "CLI for working with stacked GitHub pull requests"
+    about = "CLI for working with stacked GitHub pull requests",
+    version
 )]
 struct Cli {
     #[command(subcommand)]

--- a/tests/cli_skeleton.rs
+++ b/tests/cli_skeleton.rs
@@ -320,6 +320,16 @@ fn help_lists_all_commands() {
 }
 
 #[test]
+fn version_prints_package_version() {
+    let mut cmd = stck_cmd();
+    cmd.arg("--version");
+
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains(env!("CARGO_PKG_VERSION")));
+}
+
+#[test]
 fn commands_show_placeholder_when_preflight_passes() {
     let command = "new";
     let (_temp, mut cmd) = stck_cmd_with_stubbed_tools();


### PR DESCRIPTION
## Summary

Add native `stck --version` support via clap metadata.

This aligns CLI behavior with the v0.1 plan requirement that version information is directly available from the command line.

## Changelist

- `src/cli.rs`
  - Enable clap version metadata on the root command.
- `tests/cli_skeleton.rs`
  - Add integration test `version_prints_package_version` asserting `--version` succeeds and prints package version.

## Validation

- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features`
