### PR TITLE
Handle gh pr view errors in stck new

### DIFF
--- a/src/github.rs
+++ b/src/github.rs
@@ -45,7 +45,18 @@ pub fn pr_exists_for_head(branch: &str) -> Result<bool, String> {
 
     match output.status.code() {
         Some(0) => Ok(true),
-        Some(_) => Ok(false),
+        Some(_) => {
+            let stderr = String::from_utf8_lossy(&output.stderr).to_lowercase();
+            if stderr.contains("no pull requests found")
+                || stderr.contains("could not resolve to a pull request")
+            {
+                Ok(false)
+            } else {
+                Err(format!(
+                    "failed to check PR for branch {branch}; ensure `gh auth status` succeeds and retry"
+                ))
+            }
+        }
         None => Err("failed to determine PR presence for branch".to_string()),
     }
 }

--- a/tests/cli_skeleton.rs
+++ b/tests/cli_skeleton.rs
@@ -242,10 +242,15 @@ fi
 
 if [[ "${1:-}" == "pr" && "${2:-}" == "view" ]]; then
   branch="${3:-}"
+  if [[ "${STCK_TEST_PR_VIEW_ERROR:-0}" == "1" ]]; then
+    echo "network unavailable" >&2
+    exit 1
+  fi
   if [[ "${STCK_TEST_HAS_CURRENT_PR:-0}" == "1" && "${branch}" == "feature-branch" ]]; then
     echo '{"number":101}'
     exit 0
   fi
+  echo "no pull requests found for branch" >&2
   exit 1
 fi
 
@@ -408,6 +413,27 @@ fn new_reports_no_changes_for_new_branch_when_no_commits_exist() {
     cmd.assert().success().stdout(predicate::str::contains(
         "No changes in new stack item. Create PR for feature-next after adding commits.",
     ));
+}
+
+#[test]
+fn new_fails_when_pr_presence_check_errors() {
+    let (_temp, mut cmd) = stck_cmd_with_stubbed_tools();
+    let log_path = std::env::temp_dir().join("stck-new-pr-view-error.log");
+    let _ = fs::remove_file(&log_path);
+    cmd.env("STCK_TEST_LOG", log_path.as_os_str());
+    cmd.env("STCK_TEST_HAS_UPSTREAM", "1");
+    cmd.env("STCK_TEST_PR_VIEW_ERROR", "1");
+    cmd.args(["new", "feature-next"]);
+
+    cmd.assert().code(1).stderr(predicate::str::contains(
+        "error: failed to check PR for branch feature-branch; ensure `gh auth status` succeeds and retry",
+    ));
+
+    let log = fs::read_to_string(&log_path).unwrap_or_default();
+    assert!(
+        !log.contains("pr create"),
+        "new should not create PRs when PR presence check fails"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Make `stck new` distinguish between:
- a branch that simply has no PR yet, and
- a real GitHub CLI failure when checking PR presence.

Previously any non-zero `gh pr view` exit was treated as "no PR", which could trigger incorrect PR creation attempts during transient/auth failures.

## Changelist

- `src/github.rs`
  - Updated `pr_exists_for_head` to inspect `gh pr view` stderr.
  - Return `Ok(false)` only for recognized not-found messages.
  - Return an actionable error for other failures.
- `tests/cli_skeleton.rs`
  - Extended `gh` stub behavior for `pr view` error/not-found cases.
  - Added `new_fails_when_pr_presence_check_errors` regression test to ensure `stck new` fails fast and does not create PRs when PR presence checks fail unexpectedly.

## Checklist

- [x] Changes are minimal and focused for this task
- [x] No breaking CLI interface changes
- [x] Added test coverage for behavior change
