### PR TITLE
Precheck branch collisions in stck new

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -147,6 +147,30 @@ pub fn run() -> ExitCode {
 fn run_new(preflight: &env::PreflightContext, new_branch: &str) -> ExitCode {
     let current_branch = &preflight.current_branch;
 
+    let local_exists = match gitops::local_branch_exists(new_branch) {
+        Ok(exists) => exists,
+        Err(message) => {
+            eprintln!("error: {message}");
+            return ExitCode::from(1);
+        }
+    };
+    if local_exists {
+        eprintln!("error: branch {new_branch} already exists locally; choose a different name");
+        return ExitCode::from(1);
+    }
+
+    let remote_exists = match gitops::remote_branch_exists(new_branch) {
+        Ok(exists) => exists,
+        Err(message) => {
+            eprintln!("error: {message}");
+            return ExitCode::from(1);
+        }
+    };
+    if remote_exists {
+        eprintln!("error: branch {new_branch} already exists on origin; choose a different name");
+        return ExitCode::from(1);
+    }
+
     let has_upstream = match gitops::branch_has_upstream(current_branch) {
         Ok(has_upstream) => has_upstream,
         Err(message) => {


### PR DESCRIPTION
## Summary

Add explicit branch-collision prechecks to `stck new` so users get immediate, clear errors when the requested new branch name already exists locally or on `origin`.

This avoids relying on a later `git checkout -b` failure and prevents accidental side effects before discovering the conflict.

## Changelist

- `src/cli.rs`
  - `run_new` now fails early if:
    - `refs/heads/<new-branch>` already exists locally
    - `refs/remotes/origin/<new-branch>` already exists on remote
  - Added user-facing remediation messages for both cases.
- `src/gitops.rs`
  - Added `local_branch_exists` and `remote_branch_exists` helpers.
  - Added shared `ref_exists` helper using `git show-ref --verify --quiet`.
- `tests/cli_skeleton.rs`
  - Extended stubbed `git` to support `show-ref` checks.
  - Added regression tests:
    - `new_fails_when_new_branch_exists_locally`
    - `new_fails_when_new_branch_exists_on_origin`
  - Both tests also assert no side-effecting commands were executed.

## Checklist

- [x] Changes are minimal and focused for this task
- [x] No breaking CLI interface changes
- [x] Added test coverage for behavior change
