### PR TITLE
Validate sync --continue before advancing state

### DIFF
--- a/src/sync_state.rs
+++ b/src/sync_state.rs
@@ -9,6 +9,8 @@ pub struct SyncState {
     pub steps: Vec<SyncStep>,
     pub completed_steps: usize,
     pub failed_step: Option<usize>,
+    #[serde(default)]
+    pub failed_step_branch_head: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]


### PR DESCRIPTION
## Summary

Harden `stck sync --continue` so it no longer skips failed rebase steps after an abort-like state.

The new behavior verifies that the failed step branch actually changed before advancing progress. If no completed rebase is detected, `--continue` fails with explicit guidance instead of silently moving to the next step.

## Changelist

- `src/sync_state.rs`
  - Extend `SyncState` with `failed_step_branch_head` (serde defaulted) to track branch head at failure time.
- `src/cli.rs`
  - Capture branch HEAD before each sync rebase step.
  - Persist failed-step branch head on failure.
  - On `sync --continue`, require evidence that failed step progressed (branch HEAD changed).
  - Return actionable error when no completed rebase is detected.
- `tests/cli_skeleton.rs`
  - Add branch-head override in git stub for resume simulation.
  - Add regression: `sync_continue_fails_when_rebase_was_aborted`.
  - Update resume test expectations to match validated resume flow.

## Checklist

- [x] Changes are minimal and focused for this task
- [x] No breaking CLI interface changes
- [x] Added test coverage for behavior change
