### PR TITLE
Polish sync/new guidance and usage docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ stck sync
 stck push
 ```
 
+`stck new <branch>` works both when starting from the default branch and when stacking on top of an existing branch.
+
 Git subcommand entrypoint is also installed (when installed via homebrew):
 
 ```bash

--- a/USAGE.md
+++ b/USAGE.md
@@ -42,7 +42,7 @@ Use this command first whenever you are unsure if your branch is up to date.
 
 ### 2. Create the next stacked branch
 
-From your current stack branch:
+From your current branch:
 
 ```bash
 stck new feature-b
@@ -50,13 +50,16 @@ stck new feature-b
 
 `new` will:
 
-- ensure the current branch has an upstream on `origin`,
-- ensure the current branch has a PR (bootstraps if missing),
+- if current branch is not the default branch:
+  - ensure current branch has an upstream on `origin`,
+  - ensure current branch has a PR (bootstraps if missing),
 - create and checkout `feature-b` from current `HEAD`,
 - push `feature-b`,
-- create a PR for `feature-b` with base = current branch.
+- create a PR for `feature-b` with base:
+  - current branch (normal stacked flow), or
+  - default branch when starting a new stack from default branch.
 
-If the new branch has no commits beyond its base, `stck` does not create an empty PR and reports that PR creation should happen after adding commits.
+If the new branch has no commits beyond its base, `stck` does not create an empty PR and prints an explicit follow-up `gh pr create ...` command to run after adding commits.
 
 ### 3. Sync local stack after upstream changes
 
@@ -71,6 +74,16 @@ stck sync
 - It does not push or retarget PR bases yet.
 
 On success, it prints a follow-up message to run `stck push`.
+
+Recovery options:
+
+```bash
+# Continue an interrupted sync after resolving rebase conflicts
+stck sync --continue
+
+# Discard saved sync state and recompute from scratch
+stck sync --reset
+```
 
 ### 4. Push rewritten branches and retarget PR bases
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -292,13 +292,15 @@ fn run_sync(preflight: &env::PreflightContext, continue_sync: bool, reset_sync: 
     let mut state = match existing_state {
         Some(state) => {
             if !continue_sync {
-                println!("Resuming previous sync operation from saved state.");
+                println!(
+                    "Resuming previous sync operation from saved state. Use `stck sync --reset` to discard saved state and recompute."
+                );
             }
             state
         }
         None => {
             if continue_sync {
-                eprintln!("error: no sync state found; run `stck sync` first");
+                eprintln!("error: no sync state found; run `stck sync` to compute a new plan");
                 return ExitCode::from(1);
             }
 

--- a/tests/cli_skeleton.rs
+++ b/tests/cli_skeleton.rs
@@ -813,7 +813,7 @@ fn sync_continue_requires_existing_state() {
     cmd.args(["sync", "--continue"]);
 
     cmd.assert().code(1).stderr(predicate::str::contains(
-        "error: no sync state found; run `stck sync` first",
+        "error: no sync state found; run `stck sync` to compute a new plan",
     ));
 }
 


### PR DESCRIPTION
## Summary

Polish user guidance and docs for the newly added default-branch `new` flow and `sync --reset` recovery flow.

This keeps command behavior and user-facing instructions aligned, and makes recovery paths clearer without changing core sync/push mechanics.

## Changelist

- `src/cli.rs`
  - Improved sync state messaging:
    - resume message now points to `stck sync --reset` for explicit recompute
    - missing-state message for `--continue` now instructs to run `stck sync` to compute a plan
- `USAGE.md`
  - Updated `new` section to document both:
    - stacked branch flow
    - starting from default branch
  - Documented explicit recovery options:
    - `stck sync --continue`
    - `stck sync --reset`
  - Updated no-commit behavior text to reflect printed follow-up command.
- `README.md`
  - Added brief note that `stck new <branch>` works from default branch and stacked branches.
- `tests/cli_skeleton.rs`
  - Updated assertion for revised `sync --continue` no-state message.

## Validation

- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features`
