### PR TITLE
Fallback to origin for missing sync old-base refs

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -427,8 +427,7 @@ fn run_sync(preflight: &env::PreflightContext, continue_sync: bool, reset_sync: 
                 return ExitCode::from(1);
             }
         };
-        let old_base_ref = format!("refs/heads/{}", step.old_base_ref);
-        let old_base_sha = match gitops::resolve_ref(&old_base_ref) {
+        let old_base_sha = match gitops::resolve_old_base_for_rebase(&step.old_base_ref) {
             Ok(sha) => sha,
             Err(message) => {
                 eprintln!("error: {message}");

--- a/src/gitops.rs
+++ b/src/gitops.rs
@@ -36,6 +36,22 @@ pub fn resolve_ref(reference: &str) -> Result<String, String> {
     rev_parse(reference)
 }
 
+pub fn resolve_old_base_for_rebase(base_branch: &str) -> Result<String, String> {
+    let local_ref = format!("refs/heads/{base_branch}");
+    if let Ok(sha) = rev_parse(&local_ref) {
+        return Ok(sha);
+    }
+
+    let remote_ref = format!("refs/remotes/origin/{base_branch}");
+    if let Ok(sha) = rev_parse(&remote_ref) {
+        return Ok(sha);
+    }
+
+    Err(format!(
+        "could not resolve old base branch `{base_branch}` locally or on origin; fetch and/or restore the branch, then rerun `stck sync`"
+    ))
+}
+
 pub fn git_dir() -> Result<PathBuf, String> {
     let output = Command::new("git")
         .args(["rev-parse", "--git-dir"])


### PR DESCRIPTION
## Summary

Make sync resilient when a planned old-base branch no longer exists locally by falling back to `origin/<branch>`.

## Changelist

- `src/gitops.rs`
  - Added `resolve_old_base_for_rebase(base_branch)`:
    - tries `refs/heads/<base>` first
    - falls back to `refs/remotes/origin/<base>`
    - returns actionable error if neither resolves
- `src/cli.rs`
  - `run_sync` now uses `resolve_old_base_for_rebase` instead of local-head-only resolution.
- `tests/cli_skeleton.rs`
  - Extended git stub to simulate missing local refs and custom remote SHAs.
  - Added regression test `sync_uses_remote_old_base_when_local_old_base_is_missing`.

## Validation

- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features`
