### PR TITLE
Fetch origin before stck push

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -498,6 +498,11 @@ fn run_sync(preflight: &env::PreflightContext, continue_sync: bool, reset_sync: 
 }
 
 fn run_push(preflight: &env::PreflightContext) -> ExitCode {
+    if let Err(message) = gitops::fetch_origin() {
+        eprintln!("error: {message}");
+        return ExitCode::from(1);
+    }
+
     let existing_state = match sync_state::load_push() {
         Ok(state) => state,
         Err(message) => {

--- a/tests/cli_skeleton.rs
+++ b/tests/cli_skeleton.rs
@@ -606,6 +606,17 @@ fn push_executes_pushes_before_retargets_and_prints_summary() {
 }
 
 #[test]
+fn push_shows_fetch_failure_remediation() {
+    let (_temp, mut cmd) = stck_cmd_with_stubbed_tools();
+    cmd.env("STCK_TEST_FETCH_FAIL", "1");
+    cmd.arg("push");
+
+    cmd.assert().code(1).stderr(predicate::str::contains(
+        "error: failed to fetch from `origin`; check remote connectivity and permissions",
+    ));
+}
+
+#[test]
 fn push_stops_before_retarget_when_a_push_fails() {
     let (_temp, mut cmd) = stck_cmd_with_stubbed_tools();
     let log_path = std::env::temp_dir().join("stck-push-fail.log");


### PR DESCRIPTION
## Summary

Ensure `stck push` refreshes remote refs before planning and execution.

This reduces stale-ref risk and aligns push behavior with status/sync freshness expectations.

## Changelist

- `src/cli.rs`
  - `run_push` now runs `git fetch origin` before loading/reusing push state.
  - Push exits early with actionable error if fetch fails.
- `tests/cli_skeleton.rs`
  - Added regression test `push_shows_fetch_failure_remediation`.

## Validation

- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features`
