### PR TITLE
Push only diverged stack branches

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -540,9 +540,23 @@ fn run_push(preflight: &env::PreflightContext) -> ExitCode {
             } else {
                 stack::build_push_retargets(&stack, &preflight.default_branch)
             };
+            let mut push_branches = Vec::new();
+            for branch in stack::build_push_branches(&stack) {
+                let needs_push = match gitops::branch_needs_push(&branch) {
+                    Ok(needs_push) => needs_push,
+                    Err(message) => {
+                        eprintln!("error: {message}");
+                        return ExitCode::from(1);
+                    }
+                };
+
+                if needs_push {
+                    push_branches.push(branch);
+                }
+            }
 
             let state = PushState {
-                push_branches: stack::build_push_branches(&stack),
+                push_branches,
                 completed_pushes: 0,
                 retargets,
                 completed_retargets: 0,


### PR DESCRIPTION
## Summary

Make `stck push` force-push only branches that actually diverged from `origin`, while still applying planned retargets.

## Changelist

- `src/cli.rs`
  - During push-state creation, filter candidate push branches using `gitops::branch_needs_push`.
  - Keep retarget behavior unchanged and still ordered after pushes.
- `tests/cli_skeleton.rs`
  - Extended test stub to support multiple diverged branches via `STCK_TEST_NEEDS_PUSH_BRANCHES`.
  - Updated existing push tests to set divergence where pushes are expected.
  - Added regression test `push_skips_branches_without_local_changes`.

## Validation

- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features`
