### PR TITLE
Report per-run counts in stck push summary

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -633,6 +633,8 @@ fn run_push(preflight: &env::PreflightContext) -> ExitCode {
             state
         }
     };
+    let starting_completed_pushes = state.completed_pushes;
+    let starting_completed_retargets = state.completed_retargets;
 
     for index in state.completed_pushes..state.push_branches.len() {
         let branch = &state.push_branches[index];
@@ -683,11 +685,16 @@ fn run_push(preflight: &env::PreflightContext) -> ExitCode {
         eprintln!("error: {message}");
         return ExitCode::from(1);
     }
+    let pushed_this_run = state
+        .completed_pushes
+        .saturating_sub(starting_completed_pushes);
+    let retargeted_this_run = state
+        .completed_retargets
+        .saturating_sub(starting_completed_retargets);
 
     println!(
-        "Push succeeded. Pushed {} branch(es) and applied {} PR base update(s).",
-        state.push_branches.len(),
-        state.retargets.len()
+        "Push succeeded. Pushed {} branch(es) and applied {} PR base update(s) in this run.",
+        pushed_this_run, retargeted_this_run
     );
     ExitCode::SUCCESS
 }

--- a/tests/cli_skeleton.rs
+++ b/tests/cli_skeleton.rs
@@ -659,7 +659,7 @@ fn push_executes_pushes_before_retargets_and_prints_summary() {
             "$ gh pr edit feature-child --base feature-branch",
         ))
         .stdout(predicate::str::contains(
-            "Push succeeded. Pushed 2 branch(es) and applied 2 PR base update(s).",
+            "Push succeeded. Pushed 2 branch(es) and applied 2 PR base update(s) in this run.",
         ));
 
     let log = fs::read_to_string(&log_path).expect("push log should exist");
@@ -757,7 +757,7 @@ fn push_resumes_after_partial_retarget_failure() {
             "$ gh pr edit feature-child --base feature-branch",
         ))
         .stdout(predicate::str::contains(
-            "Push succeeded. Pushed 2 branch(es) and applied 2 PR base update(s).",
+            "Push succeeded. Pushed 0 branch(es) and applied 1 PR base update(s) in this run.",
         ));
 
     let log = fs::read_to_string(&log_path).expect("push log should exist");
@@ -836,7 +836,7 @@ fn push_skips_branches_without_local_changes() {
     cmd.arg("push");
 
     cmd.assert().success().stdout(predicate::str::contains(
-        "Push succeeded. Pushed 0 branch(es) and applied 2 PR base update(s).",
+        "Push succeeded. Pushed 0 branch(es) and applied 2 PR base update(s) in this run.",
     ));
 
     let log = fs::read_to_string(&log_path).expect("push log should exist");


### PR DESCRIPTION
## Summary

Make `stck push` summary counts reflect work performed in the current run, not total plan size.

## Changelist

- `src/cli.rs`
  - Captures starting progress counters before push/retarget loops.
  - Computes `pushed_this_run` and `retargeted_this_run` from completed deltas.
  - Updates final summary message to report per-run counts.
- `tests/cli_skeleton.rs`
  - Updated push summary expectations for both fresh and resumed runs.

## Validation

- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features`
