### PR TITLE
P2: shared sync check helper + PR discovery hardening

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Command surface:
 
 ```bash
 stck new <branch>
+stck submit [--base <branch>]
 stck status
 stck sync
 stck push

--- a/USAGE.md
+++ b/USAGE.md
@@ -13,6 +13,7 @@ This guide describes the expected `stck` workflow in a stacked PR repository.
 
 ```bash
 stck new <branch>
+stck submit [--base <branch>]
 stck status
 stck sync
 stck push
@@ -60,6 +61,20 @@ stck new feature-b
   - default branch when starting a new stack from default branch.
 
 If the new branch has no commits beyond its base, `stck` does not create an empty PR and prints an explicit follow-up `gh pr create ...` command to run after adding commits.
+
+### 2b. Submit PR for current branch
+
+```bash
+stck submit
+# or:
+stck submit --base feature-a
+```
+
+`submit` creates a PR for the current branch when one does not exist.
+
+- If no `--base` is provided, it defaults to the repository default branch.
+- Use `--base` to target a stack parent branch explicitly.
+- If the current branch already has a PR, it reports a no-op.
 
 ### 3. Sync local stack after upstream changes
 


### PR DESCRIPTION
## Summary

Apply P2 polish across sync/status discovery and documentation:
- remove duplicated first-open/default-root sync-check logic,
- harden PR discovery against silent limit truncation,
- align docs with new `submit` command surface.

## Changelist

- `src/stack.rs`
  - Added `first_open_branch_rooted_on_default` helper to centralize first-open/default-root detection.
  - Added unit tests for helper behavior.
- `src/cli.rs`
  - Replaced duplicated first-open/default-root logic in both `status` and `sync` planning with shared helper.
- `src/github.rs`
  - Increased PR list discovery limit from `500` to `1000`.
  - Added explicit guard error when returned list hits limit, preventing silent truncation assumptions.
  - Added unit test for limit guard.
- `README.md`
  - Added `submit` to command surface.
- `USAGE.md`
  - Added `submit` usage section and behavior details.

## Validation

- `cargo fmt --all --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features`
