### PR TITLE
Harden sync rebase boundary derivation

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -484,7 +484,11 @@ fn run_sync(preflight: &env::PreflightContext, continue_sync: bool, reset_sync: 
                 return ExitCode::from(1);
             }
         };
-        let old_base_sha = match gitops::resolve_old_base_for_rebase(&step.old_base_ref) {
+        let old_base_sha = match gitops::derive_rebase_boundary(
+            &step.old_base_ref,
+            &step.new_base_ref,
+            &step.branch,
+        ) {
             Ok(sha) => sha,
             Err(message) => {
                 eprintln!("error: {message}");

--- a/tests/cli_skeleton.rs
+++ b/tests/cli_skeleton.rs
@@ -171,6 +171,71 @@ if [[ "${1:-}" == "rev-list" && "${2:-}" == "--count" ]]; then
   exit 0
 fi
 
+if [[ "${1:-}" == "merge-base" && "${2:-}" == "--fork-point" ]]; then
+  base="${3:-}"
+  branch="${4:-}"
+
+  if [[ "${STCK_TEST_FORK_POINT_FAIL:-0}" == "1" ]]; then
+    exit 1
+  fi
+
+  if [[ "${base}" == "refs/heads/feature-base" || "${base}" == "refs/remotes/origin/feature-base" ]]; then
+    if [[ "${branch}" == "refs/heads/feature-branch" ]]; then
+      echo "1111111111111111111111111111111111111111"
+      exit 0
+    fi
+  fi
+
+  if [[ "${base}" == "refs/heads/feature-branch" || "${base}" == "refs/remotes/origin/feature-branch" ]]; then
+    if [[ "${branch}" == "refs/heads/feature-child" ]]; then
+      echo "2222222222222222222222222222222222222222"
+      exit 0
+    fi
+  fi
+
+  exit 1
+fi
+
+if [[ "${1:-}" == "merge-base" && "${2:-}" != "--is-ancestor" ]]; then
+  base="${2:-}"
+  branch="${3:-}"
+
+  if [[ "${STCK_TEST_MERGE_BASE_FAIL:-0}" == "1" ]]; then
+    exit 1
+  fi
+
+  if [[ "${base}" == "refs/heads/feature-base" || "${base}" == "refs/remotes/origin/feature-base" ]]; then
+    if [[ "${branch}" == "refs/heads/feature-branch" ]]; then
+      echo "1111111111111111111111111111111111111111"
+      exit 0
+    fi
+  fi
+
+  if [[ "${base}" == "refs/heads/feature-branch" || "${base}" == "refs/remotes/origin/feature-branch" ]]; then
+    if [[ "${branch}" == "refs/heads/feature-child" ]]; then
+      if [[ -n "${STCK_TEST_FEATURE_CHILD_BOUNDARY_SHA:-}" ]]; then
+        echo "${STCK_TEST_FEATURE_CHILD_BOUNDARY_SHA}"
+      else
+        echo "2222222222222222222222222222222222222222"
+      fi
+      exit 0
+    fi
+  fi
+
+  if [[ "${base}" == "refs/heads/main" || "${base}" == "refs/remotes/origin/main" ]]; then
+    if [[ "${branch}" == "refs/heads/feature-branch" ]]; then
+      echo "1111111111111111111111111111111111111111"
+      exit 0
+    fi
+    if [[ "${branch}" == "refs/heads/feature-child" ]]; then
+      echo "2222222222222222222222222222222222222222"
+      exit 0
+    fi
+  fi
+
+  exit 1
+fi
+
 if [[ "${1:-}" == "merge-base" && "${2:-}" == "--is-ancestor" ]]; then
   ancestor="${3:-}"
   descendant="${4:-}"
@@ -880,6 +945,38 @@ fn sync_executes_rebase_plan_and_prints_success_message() {
 }
 
 #[test]
+fn sync_uses_merge_base_when_fork_point_is_unavailable() {
+    let (_temp, mut cmd) = stck_cmd_with_stubbed_tools();
+    cmd.env("STCK_TEST_FORK_POINT_FAIL", "1");
+    cmd.env(
+        "STCK_TEST_FEATURE_CHILD_BOUNDARY_SHA",
+        "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    );
+    cmd.arg("sync");
+
+    cmd.assert().success().stdout(predicate::str::contains(
+        "$ git rebase --onto feature-branch bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb feature-child",
+    ));
+}
+
+#[test]
+fn sync_falls_back_to_old_base_ref_when_merge_base_lookups_fail() {
+    let (_temp, mut cmd) = stck_cmd_with_stubbed_tools();
+    cmd.env("STCK_TEST_FORK_POINT_FAIL", "1");
+    cmd.env("STCK_TEST_MERGE_BASE_FAIL", "1");
+    cmd.env(
+        "STCK_TEST_REMOTE_FEATURE_BASE_SHA",
+        "9999999999999999999999999999999999999999",
+    );
+    cmd.env("STCK_TEST_MISSING_LOCAL_BRANCH_REF", "feature-base");
+    cmd.arg("sync");
+
+    cmd.assert().success().stdout(predicate::str::contains(
+        "$ git rebase --onto main 9999999999999999999999999999999999999999 feature-branch",
+    ));
+}
+
+#[test]
 fn sync_uses_remote_old_base_when_local_old_base_is_missing() {
     let (_temp, mut cmd) = stck_cmd_with_stubbed_tools();
     cmd.env("STCK_TEST_MISSING_LOCAL_BRANCH_REF", "feature-base");
@@ -890,7 +987,7 @@ fn sync_uses_remote_old_base_when_local_old_base_is_missing() {
     cmd.arg("sync");
 
     cmd.assert().success().stdout(predicate::str::contains(
-        "$ git rebase --onto main 9999999999999999999999999999999999999999 feature-branch",
+        "$ git rebase --onto main 1111111111111111111111111111111111111111 feature-branch",
     ));
 }
 
@@ -1013,7 +1110,7 @@ fn sync_continue_resumes_after_previous_failure() {
         .assert()
         .success()
         .stdout(predicate::str::contains(
-            "$ git rebase --onto feature-branch bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb feature-child",
+            "$ git rebase --onto feature-branch 2222222222222222222222222222222222222222 feature-child",
         ))
         .stdout(predicate::str::contains(
             "Sync succeeded locally. Run `stck push` to update remotes + PR bases.",
@@ -1022,7 +1119,7 @@ fn sync_continue_resumes_after_previous_failure() {
     let log = fs::read_to_string(&log_path).expect("rebase log should exist");
     let first_step = "rebase --onto main 1111111111111111111111111111111111111111 feature-branch";
     let second_step =
-        "rebase --onto feature-branch bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb feature-child";
+        "rebase --onto feature-branch 2222222222222222222222222222222222222222 feature-child";
     assert_eq!(log.matches(first_step).count(), 1);
     assert_eq!(log.matches(second_step).count(), 1);
     assert!(


### PR DESCRIPTION
### Motivation
- Improve reliability of `stck sync` rebase boundaries so rewritten ancestry (including squash-merge flows) yields correct `git rebase --onto` boundaries. 
- Preserve the existing `--onto` execution model while making boundary selection more robust against missing local refs and rewritten history. 
- Cover regressions observed in sync/push flows with deterministic, testable fallbacks.

### Description
- Add `gitops::derive_rebase_boundary` which attempts `git merge-base --fork-point` (old-base candidates), then `git merge-base` (old-base candidates), then `git merge-base` (new-base candidates), and finally falls back to existing old-base ref resolution. 
- Replace the old `resolve_old_base_for_rebase` call in `sync` execution with `derive_rebase_boundary` so each rebase step uses the derived boundary SHA. 
- Extend the CLI test stubs in `tests/cli_skeleton.rs` to simulate `merge-base --fork-point` and `merge-base` behaviors and add regression tests for fork-point fallback, merge-base fallback, and missing-local-old-base fallback. 
- Changes are limited to `src/gitops.rs`, `src/cli.rs`, and `tests/cli_skeleton.rs` to keep the diff focused on Milestone A scope.

### Testing
- Ran formatting and linting with `cargo fmt --all` and `cargo clippy --all-targets --all-features -- -D warnings`, and both completed successfully. 
- Executed the full test suite with `cargo test --all-features`, which ran unit tests (20 tests) and CLI/integration tests (44 tests) for a total of 64 tests and all tests passed. 
- New/updated tests exercised fork-point and merge-base fallbacks and the missing-local-old-base fallback and all assertions succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d87b06ea8832890f600c869b47ff8)