### PR TITLE
Replace bulk PR fetch with iterative per-branch discovery

### DIFF
--- a/src/github.rs
+++ b/src/github.rs
@@ -1,10 +1,7 @@
 use serde::Deserialize;
-use std::collections::HashMap;
 use std::process::Command;
 
 use crate::util::with_stderr;
-
-const PR_LIST_LIMIT: usize = 1000;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
@@ -38,8 +35,69 @@ pub fn discover_linear_stack(
     current_branch: &str,
     default_branch: &str,
 ) -> Result<Vec<PullRequest>, String> {
-    let prs = list_pull_requests()?;
-    build_linear_stack(&prs, current_branch, default_branch)
+    let current = fetch_pr_for_branch(current_branch)?;
+
+    let mut seen = vec![current.head_ref_name.clone()];
+    let mut to_current = vec![current.clone()];
+    let mut cursor_base = current.base_ref_name.clone();
+
+    // Walk up to root (default branch)
+    while cursor_base != default_branch {
+        let parent = fetch_pr_for_branch(&cursor_base)?;
+        if seen.iter().any(|b| b == &parent.head_ref_name) {
+            return Err(format!(
+                "cycle detected in stack at branch {}",
+                parent.head_ref_name
+            ));
+        }
+        seen.push(parent.head_ref_name.clone());
+        cursor_base = parent.base_ref_name.clone();
+        to_current.push(parent);
+    }
+
+    // Walk down from current to tip
+    let mut cursor_head = current.head_ref_name.clone();
+    let mut below_current: Vec<PullRequest> = Vec::new();
+    loop {
+        let children = fetch_children_for_base(&cursor_head)?;
+        let mut eligible: Vec<PullRequest> = children
+            .into_iter()
+            .filter(|pr| pr.state != PrState::Closed)
+            .collect();
+        eligible.sort_by(|a, b| a.head_ref_name.cmp(&b.head_ref_name));
+
+        match eligible.len() {
+            0 => break,
+            1 => {
+                let child = eligible.into_iter().next().unwrap();
+                if seen.iter().any(|b| b == &child.head_ref_name) {
+                    return Err(format!(
+                        "cycle detected in stack at branch {}",
+                        child.head_ref_name
+                    ));
+                }
+                seen.push(child.head_ref_name.clone());
+                cursor_head = child.head_ref_name.clone();
+                below_current.push(child);
+            }
+            _ => {
+                let candidates = eligible
+                    .iter()
+                    .map(|c| c.head_ref_name.as_str())
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                return Err(format!(
+                    "non-linear stack detected at {}; child candidates: {}",
+                    cursor_head, candidates
+                ));
+            }
+        }
+    }
+
+    to_current.reverse();
+    let mut stack = to_current;
+    stack.extend(below_current);
+    Ok(stack)
 }
 
 pub fn retarget_pr_base(branch: &str, new_base: &str) -> Result<(), String> {
@@ -130,15 +188,48 @@ pub fn list_open_prs() -> Result<Vec<PullRequest>, String> {
     parse_pull_requests_json(&output.stdout)
 }
 
-fn list_pull_requests() -> Result<Vec<PullRequest>, String> {
+fn fetch_pr_for_branch(branch: &str) -> Result<PullRequest, String> {
+    let output = Command::new("gh")
+        .args([
+            "pr",
+            "view",
+            branch,
+            "--json",
+            "number,headRefName,baseRefName,state",
+        ])
+        .output()
+        .map_err(|_| "failed to run `gh pr view`; ensure GitHub CLI is installed".to_string())?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).to_lowercase();
+        if stderr.contains("no pull requests found")
+            || stderr.contains("could not resolve to a pull request")
+        {
+            return Err(format!(
+                "no PR found for branch {branch}; create a PR first"
+            ));
+        }
+        return Err(with_stderr(
+            &format!("failed to fetch PR for branch {branch}"),
+            &output.stderr,
+        ));
+    }
+
+    serde_json::from_slice::<PullRequest>(&output.stdout)
+        .map_err(|_| format!("failed to parse PR metadata for branch {branch}"))
+}
+
+fn fetch_children_for_base(branch: &str) -> Result<Vec<PullRequest>, String> {
     let output = Command::new("gh")
         .args([
             "pr",
             "list",
+            "--base",
+            branch,
             "--state",
             "all",
             "--limit",
-            "1000",
+            "100",
             "--json",
             "number,headRefName,baseRefName,state",
         ])
@@ -147,13 +238,12 @@ fn list_pull_requests() -> Result<Vec<PullRequest>, String> {
 
     if !output.status.success() {
         return Err(with_stderr(
-            "failed to list pull requests from GitHub; ensure `gh auth status` succeeds and the repository is accessible",
+            &format!("failed to list PRs with base {branch}"),
             &output.stderr,
         ));
     }
 
-    let prs = parse_pull_requests_json(&output.stdout)?;
-    enforce_pr_list_limit(prs)
+    parse_pull_requests_json(&output.stdout)
 }
 
 fn parse_pull_requests_json(bytes: &[u8]) -> Result<Vec<PullRequest>, String> {
@@ -161,20 +251,13 @@ fn parse_pull_requests_json(bytes: &[u8]) -> Result<Vec<PullRequest>, String> {
         .map_err(|_| "failed to parse PR metadata from GitHub CLI output".to_string())
 }
 
-fn enforce_pr_list_limit(prs: Vec<PullRequest>) -> Result<Vec<PullRequest>, String> {
-    if prs.len() == PR_LIST_LIMIT {
-        return Err(format!(
-            "pull request discovery hit limit ({PR_LIST_LIMIT}); rerun after reducing PR scope or extend pagination support"
-        ));
-    }
-    Ok(prs)
-}
-
+#[cfg(test)]
 pub fn build_linear_stack(
     prs: &[PullRequest],
     current_branch: &str,
     default_branch: &str,
 ) -> Result<Vec<PullRequest>, String> {
+    use std::collections::HashMap;
     let by_head: HashMap<&str, &PullRequest> = prs
         .iter()
         .map(|pr| (pr.head_ref_name.as_str(), pr))
@@ -261,7 +344,7 @@ pub fn build_linear_stack(
 
 #[cfg(test)]
 mod tests {
-    use super::{build_linear_stack, enforce_pr_list_limit, PrState, PullRequest, PR_LIST_LIMIT};
+    use super::{build_linear_stack, PrState, PullRequest};
 
     fn pr(number: u64, head: &str, base: &str) -> PullRequest {
         PullRequest {
@@ -454,23 +537,5 @@ mod tests {
 
         let parsed = serde_json::from_str::<Vec<PullRequest>>(raw);
         assert!(parsed.is_err(), "malformed list JSON should fail parse");
-    }
-
-    #[test]
-    fn errors_when_pull_request_list_hits_limit() {
-        let prs = (0..PR_LIST_LIMIT)
-            .map(|i| PullRequest {
-                number: i as u64,
-                head_ref_name: format!("feature-{i}"),
-                base_ref_name: "main".to_string(),
-                state: PrState::Open,
-            })
-            .collect::<Vec<_>>();
-
-        let error = enforce_pr_list_limit(prs).expect_err("limit should trigger error");
-        assert_eq!(
-            error,
-            "pull request discovery hit limit (1000); rerun after reducing PR scope or extend pagination support"
-        );
     }
 }

--- a/tests/cli_skeleton.rs
+++ b/tests/cli_skeleton.rs
@@ -350,48 +350,103 @@ if [[ "${1:-}" == "pr" && "${2:-}" == "list" ]]; then
     exit 1
   fi
 
-  # Detect --state flag
+  # Detect --state and --base flags
   pr_list_state="all"
+  pr_list_base=""
   for ((i=1; i<=$#; i++)); do
     if [[ "${!i}" == "--state" ]]; then
       next=$((i+1))
       pr_list_state="${!next}"
     fi
+    if [[ "${!i}" == "--base" ]]; then
+      next=$((i+1))
+      pr_list_base="${!next}"
+    fi
   done
 
-  if [[ "${STCK_TEST_NON_LINEAR:-0}" == "1" ]]; then
-    echo '[{"number":100,"headRefName":"feature-base","baseRefName":"main","state":"MERGED","mergedAt":"2026-01-01T00:00:00Z"},{"number":101,"headRefName":"feature-branch","baseRefName":"feature-base","state":"OPEN","mergedAt":null},{"number":102,"headRefName":"feature-child-a","baseRefName":"feature-branch","state":"OPEN","mergedAt":null},{"number":103,"headRefName":"feature-child-b","baseRefName":"feature-branch","state":"OPEN","mergedAt":null}]'
+  # Targeted child discovery: gh pr list --base <branch>
+  if [[ -n "${pr_list_base}" ]]; then
+    if [[ "${STCK_TEST_NON_LINEAR:-0}" == "1" && "${pr_list_base}" == "feature-branch" ]]; then
+      echo '[{"number":102,"headRefName":"feature-child-a","baseRefName":"feature-branch","state":"OPEN"},{"number":103,"headRefName":"feature-child-b","baseRefName":"feature-branch","state":"OPEN"}]'
+      exit 0
+    fi
+    if [[ "${STCK_TEST_SYNC_NOOP:-0}" == "1" ]]; then
+      case "${pr_list_base}" in
+        main) echo '[{"number":100,"headRefName":"feature-base","baseRefName":"main","state":"OPEN"}]' ;;
+        feature-base) echo '[{"number":101,"headRefName":"feature-branch","baseRefName":"feature-base","state":"OPEN"}]' ;;
+        feature-branch) echo '[{"number":102,"headRefName":"feature-child","baseRefName":"feature-branch","state":"OPEN"}]' ;;
+        *) echo '[]' ;;
+      esac
+      exit 0
+    fi
+    # Default children for the default stack
+    case "${pr_list_base}" in
+      feature-base) echo '[{"number":101,"headRefName":"feature-branch","baseRefName":"feature-base","state":"OPEN"}]' ;;
+      feature-branch) echo '[{"number":102,"headRefName":"feature-child","baseRefName":"feature-branch","state":"OPEN"}]' ;;
+      *) echo '[]' ;;
+    esac
     exit 0
   fi
 
-  if [[ "${STCK_TEST_MISSING_CURRENT_PR:-0}" == "1" ]]; then
-    echo '[{"number":100,"headRefName":"feature-base","baseRefName":"main","state":"MERGED","mergedAt":"2026-01-01T00:00:00Z"}]'
-    exit 0
-  fi
-
-  if [[ "${STCK_TEST_SYNC_NOOP:-0}" == "1" ]]; then
-    echo '[{"number":100,"headRefName":"feature-base","baseRefName":"main","state":"OPEN","mergedAt":null},{"number":101,"headRefName":"feature-branch","baseRefName":"feature-base","state":"OPEN","mergedAt":null},{"number":102,"headRefName":"feature-child","baseRefName":"feature-branch","state":"OPEN","mergedAt":null}]'
-    exit 0
-  fi
-
+  # Bulk list (used by list_open_prs for parent discovery)
   if [[ -n "${STCK_TEST_OPEN_PRS_JSON:-}" && "${pr_list_state}" == "open" ]]; then
     echo "${STCK_TEST_OPEN_PRS_JSON}"
     exit 0
   fi
 
-  # Default: return all PRs (merged + open)
-  echo '[{"number":100,"headRefName":"feature-base","baseRefName":"main","state":"MERGED","mergedAt":"2026-01-01T00:00:00Z"},{"number":101,"headRefName":"feature-branch","baseRefName":"feature-base","state":"OPEN","mergedAt":null},{"number":102,"headRefName":"feature-child","baseRefName":"feature-branch","state":"OPEN","mergedAt":null}]'
+  # Default bulk list for list_open_prs
+  echo '[]'
   exit 0
 fi
 
 if [[ "${1:-}" == "pr" && "${2:-}" == "view" ]]; then
   branch="${3:-}"
+  all_args="$*"
+
   if [[ "${STCK_TEST_PR_VIEW_ERROR:-0}" == "1" ]]; then
     echo "network unavailable" >&2
     exit 1
   fi
+
+  # Stack discovery path (full field set including headRefName)
+  if [[ "${all_args}" == *"headRefName"* ]]; then
+    if [[ "${STCK_TEST_MISSING_CURRENT_PR:-0}" == "1" && "${branch}" == "feature-branch" ]]; then
+      echo "no pull requests found for branch ${branch}" >&2
+      exit 1
+    fi
+
+    if [[ "${STCK_TEST_NON_LINEAR:-0}" == "1" ]]; then
+      case "${branch}" in
+        feature-base) echo '{"number":100,"headRefName":"feature-base","baseRefName":"main","state":"MERGED"}' ;;
+        feature-branch) echo '{"number":101,"headRefName":"feature-branch","baseRefName":"feature-base","state":"OPEN"}' ;;
+        *) echo "no pull requests found for branch ${branch}" >&2; exit 1 ;;
+      esac
+      exit 0
+    fi
+
+    if [[ "${STCK_TEST_SYNC_NOOP:-0}" == "1" ]]; then
+      case "${branch}" in
+        feature-base) echo '{"number":100,"headRefName":"feature-base","baseRefName":"main","state":"OPEN"}' ;;
+        feature-branch) echo '{"number":101,"headRefName":"feature-branch","baseRefName":"feature-base","state":"OPEN"}' ;;
+        feature-child) echo '{"number":102,"headRefName":"feature-child","baseRefName":"feature-branch","state":"OPEN"}' ;;
+        *) echo "no pull requests found for branch ${branch}" >&2; exit 1 ;;
+      esac
+      exit 0
+    fi
+
+    # Default: feature-base(merged) -> feature-branch(open) -> feature-child(open)
+    case "${branch}" in
+      feature-base) echo '{"number":100,"headRefName":"feature-base","baseRefName":"main","state":"MERGED"}' ;;
+      feature-branch) echo '{"number":101,"headRefName":"feature-branch","baseRefName":"feature-base","state":"OPEN"}' ;;
+      feature-child) echo '{"number":102,"headRefName":"feature-child","baseRefName":"feature-branch","state":"OPEN"}' ;;
+      *) echo "no pull requests found for branch ${branch}" >&2; exit 1 ;;
+    esac
+    exit 0
+  fi
+
+  # Legacy: pr_exists_for_head check (--json number)
   if [[ "${STCK_TEST_HAS_CURRENT_PR:-0}" == "1" && "${branch}" == "feature-branch" ]]; then
-    echo '{"number":101,"headRefName":"feature-branch","baseRefName":"feature-base","state":"OPEN","mergedAt":null}'
+    echo '{"number":101}'
     exit 0
   fi
   echo "no pull requests found for branch" >&2


### PR DESCRIPTION
## Summary

Replace the `gh pr list --state all --limit 1000` bulk fetch in stack discovery with targeted, per-branch queries. This eliminates the 1000-PR truncation limit and avoids fetching irrelevant PRs on large repos.

Stack discovery now walks the graph iteratively:
1. Fetches the current branch's PR via `gh pr view`
2. Walks up to the root by fetching each parent PR individually
3. Walks down to the tip by querying children via `gh pr list --base <branch>`

For a typical 3-deep stack, this makes 6 targeted calls instead of 1 bulk fetch of up to 1000 PRs.

## Changelist

- `src/github.rs` — Rewrote `discover_linear_stack` to use iterative fetching; added `fetch_pr_for_branch` and `fetch_children_for_base` helpers; removed `list_pull_requests`, `enforce_pr_list_limit`, and `PR_LIST_LIMIT`; moved `build_linear_stack` behind `#[cfg(test)]`
- `tests/cli_skeleton.rs` — Updated `gh` stub to handle per-branch `pr view` (full field set) and per-base `pr list --base` for child discovery

## Checklist

- [x] Changes are minimal and focused for this milestone
- [x] No breaking CLI changes unless explicitly intended
- [x] Errors are user-facing, actionable, and prefixed with `error:`
- [x] Added/updated tests for behavior changes
- [x] Updated docs/plan if behavior or scope changed