### PR TITLE
Polish status output and add branch name validation

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -59,6 +59,14 @@ pub fn run() -> ExitCode {
 
     match cli.command {
         Commands::Status => {
+            if preflight.current_branch == preflight.default_branch {
+                println!(
+                    "On default branch ({}). Run `stck new <branch>` to start a new stack.",
+                    preflight.default_branch
+                );
+                return ExitCode::SUCCESS;
+            }
+
             if let Err(message) = gitops::fetch_origin() {
                 eprintln!("error: {message}");
                 return ExitCode::from(1);
@@ -126,19 +134,24 @@ pub fn run() -> ExitCode {
             println!("Stack: {} <- {}", preflight.default_branch, branch_chain);
 
             for line in report.lines {
-                let flags = if line.flags.is_empty() {
-                    "none".to_string()
+                let marker = if line.branch == preflight.current_branch {
+                    "* "
                 } else {
-                    line.flags.join(",")
+                    "  "
+                };
+                let flags = if line.flags.is_empty() {
+                    String::new()
+                } else {
+                    format!(" [{}]", line.flags.join(", "))
                 };
                 println!(
-                    "{} PR #{} [{}] base={} head={} flags={}",
-                    line.branch, line.number, line.state, line.base, line.head, flags
+                    "{}{} PR #{} {} base={}{}",
+                    marker, line.branch, line.number, line.state, line.base, flags
                 );
             }
 
             println!(
-                "Summary: needs_sync={} needs_push={} base_mismatch={}",
+                "Summary: {} needs_sync, {} needs_push, {} base_mismatch",
                 report.summary.needs_sync, report.summary.needs_push, report.summary.base_mismatch
             );
 
@@ -162,6 +175,20 @@ fn run_new(preflight: &env::PreflightContext, new_branch: &str) -> ExitCode {
     } else {
         current_branch.as_str()
     };
+
+    match gitops::is_valid_branch_name(new_branch) {
+        Ok(true) => {}
+        Ok(false) => {
+            eprintln!(
+                "error: `{new_branch}` is not a valid branch name; use only alphanumeric characters, hyphens, underscores, and slashes"
+            );
+            return ExitCode::from(1);
+        }
+        Err(message) => {
+            eprintln!("error: {message}");
+            return ExitCode::from(1);
+        }
+    }
 
     let local_exists = match gitops::local_branch_exists(new_branch) {
         Ok(exists) => exists,

--- a/src/gitops.rs
+++ b/src/gitops.rs
@@ -303,6 +303,19 @@ fn rev_parse(reference: &str) -> Result<String, String> {
     }
 }
 
+pub fn is_valid_branch_name(name: &str) -> Result<bool, String> {
+    let output = Command::new("git")
+        .args(["check-ref-format", "--allow-onelevel", name])
+        .output()
+        .map_err(|_| "failed to run `git check-ref-format`".to_string())?;
+
+    match output.status.code() {
+        Some(0) => Ok(true),
+        Some(_) => Ok(false),
+        None => Err("failed to validate branch name".to_string()),
+    }
+}
+
 fn ref_exists(reference: &str) -> Result<bool, String> {
     let output = Command::new("git")
         .args(["show-ref", "--verify", "--quiet", reference])

--- a/tests/cli_skeleton.rs
+++ b/tests/cli_skeleton.rs
@@ -315,6 +315,16 @@ if [[ "${1:-}" == "checkout" ]]; then
   exit 0
 fi
 
+if [[ "${1:-}" == "check-ref-format" ]]; then
+  shift
+  while [[ "${1:-}" == --* ]]; do shift; done
+  name="${1:-}"
+  if [[ "${name}" == *" "* || "${name}" == *".."* || "${name}" == *"~"* || "${name}" == *"^"* || "${name}" == *":"* || "${name}" == *"\\"* ]]; then
+    exit 1
+  fi
+  exit 0
+fi
+
 exit 0
 "#,
     );
@@ -843,6 +853,16 @@ fn new_fails_when_new_branch_exists_on_origin() {
         log.is_empty(),
         "new should fail before running side-effecting commands"
     );
+}
+
+#[test]
+fn new_rejects_invalid_branch_name() {
+    let (_temp, mut cmd) = stck_cmd_with_stubbed_tools();
+    cmd.args(["new", "feature branch"]);
+
+    cmd.assert().code(1).stderr(predicate::str::contains(
+        "error: `feature branch` is not a valid branch name",
+    ));
 }
 
 #[test]
@@ -1396,16 +1416,16 @@ fn status_discovers_linear_stack_in_order() {
             "Stack: main <- feature-base <- feature-branch <- feature-child",
         ))
         .stdout(predicate::str::contains(
-            "feature-base PR #100 [MERGED] base=main head=feature-base flags=none",
+            "feature-base PR #100 MERGED base=main",
         ))
         .stdout(predicate::str::contains(
-            "feature-branch PR #101 [OPEN] base=feature-base head=feature-branch flags=needs_sync",
+            "* feature-branch PR #101 OPEN base=feature-base [needs_sync]",
         ))
         .stdout(predicate::str::contains(
-            "feature-child PR #102 [OPEN] base=feature-branch head=feature-child flags=none",
+            "feature-child PR #102 OPEN base=feature-branch",
         ))
         .stdout(predicate::str::contains(
-            "Summary: needs_sync=1 needs_push=0 base_mismatch=0",
+            "Summary: 1 needs_sync, 0 needs_push, 0 base_mismatch",
         ));
 }
 
@@ -1484,10 +1504,10 @@ fn status_reports_needs_push_when_branch_diverges_from_origin() {
     cmd.assert()
         .success()
         .stdout(predicate::str::contains(
-            "feature-child PR #102 [OPEN] base=feature-branch head=feature-child flags=needs_push",
+            "feature-child PR #102 OPEN base=feature-branch [needs_push]",
         ))
         .stdout(predicate::str::contains(
-            "Summary: needs_sync=1 needs_push=1 base_mismatch=0",
+            "Summary: 1 needs_sync, 1 needs_push, 0 base_mismatch",
         ));
 }
 
@@ -1501,11 +1521,22 @@ fn status_reports_needs_sync_when_default_branch_has_advanced() {
     cmd.assert()
         .success()
         .stdout(predicate::str::contains(
-            "feature-base PR #100 [OPEN] base=main head=feature-base flags=needs_sync",
+            "feature-base PR #100 OPEN base=main [needs_sync]",
         ))
         .stdout(predicate::str::contains(
-            "Summary: needs_sync=1 needs_push=0 base_mismatch=0",
+            "Summary: 1 needs_sync, 0 needs_push, 0 base_mismatch",
         ));
+}
+
+#[test]
+fn status_from_default_branch_shows_helpful_message() {
+    let (_temp, mut cmd) = stck_cmd_with_stubbed_tools();
+    cmd.env("STCK_TEST_CURRENT_BRANCH", "main");
+    cmd.arg("status");
+
+    cmd.assert().success().stdout(predicate::str::contains(
+        "On default branch (main). Run `stck new <branch>` to start a new stack.",
+    ));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- **Status output**: Add `*` marker for current branch, hide empty flags, use human-readable summary format (`3 needs_sync, 2 needs_push`)
- **Default branch status**: Show helpful message instead of attempting stack discovery when on the default branch
- **Branch name validation**: Validate branch names early in `stck new` via `git check-ref-format` before any git operations
- Skipped residuals with no actionable changes: no-op retarget suppression (already correct), duplicate-PR policy (`gh pr view` handles naturally), `--no-fetch` (no alpha demand)

## Test plan
- [x] `status_from_default_branch_shows_helpful_message` — verifies early return with guidance message
- [x] `new_rejects_invalid_branch_name` — verifies rejection of names with spaces/special chars
- [x] Updated all status assertions to match new output format
- [x] All 56 tests pass, clippy and fmt clean