### PR TITLE
Make Sync Retry Explicit

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -549,10 +549,12 @@ fn run_sync(preflight: &env::PreflightContext, continue_sync: bool, reset_sync: 
                 state.completed_steps = failed_step + 1;
             }
         } else {
-            // For plain sync retries, keep legacy behavior and continue from next step.
-            if state.completed_steps <= failed_step {
-                state.completed_steps = failed_step + 1;
-            }
+            let step = &state.steps[failed_step];
+            eprintln!(
+                "error: sync stopped at failed step for {}; run `stck sync --continue` after completing the rebase, or `stck sync --reset` to discard saved state and recompute",
+                step.branch
+            );
+            return ExitCode::from(1);
         }
         state.failed_step = None;
         state.failed_step_branch_head = None;

--- a/tests/cli_skeleton.rs
+++ b/tests/cli_skeleton.rs
@@ -1406,6 +1406,47 @@ fn sync_continue_fails_when_rebase_was_aborted() {
 }
 
 #[test]
+fn sync_plain_retry_requires_continue_or_reset_after_failure() {
+    let (temp, mut first) = stck_cmd_with_stubbed_tools();
+    let fail_once_path = temp.path().join("fail-once-plain-retry.marker");
+
+    first.env(
+        "STCK_TEST_REBASE_FAIL_ONCE_FILE",
+        fail_once_path.as_os_str(),
+    );
+    first.arg("sync");
+    first.assert().code(1).stderr(predicate::str::contains(
+        "error: rebase failed for branch feature-branch; resolve conflicts, run `git rebase --continue` or `git rebase --abort`, then rerun `stck sync`",
+    ));
+
+    let state_path = temp
+        .path()
+        .join("git-dir")
+        .join("stck")
+        .join("last-plan.json");
+    assert!(
+        state_path.exists(),
+        "sync state should persist after failure"
+    );
+
+    let mut retry = stck_cmd();
+    let path = std::env::var("PATH").expect("PATH should be set");
+    let full_path = format!("{}:{}", temp.path().join("bin").display(), path);
+    retry.env("PATH", full_path);
+    retry.env("STCK_TEST_GIT_DIR", temp.path().join("git-dir").as_os_str());
+    retry.arg("sync");
+
+    retry.assert().code(1).stderr(predicate::str::contains(
+        "error: sync stopped at failed step for feature-branch; run `stck sync --continue` after completing the rebase, or `stck sync --reset` to discard saved state and recompute",
+    ));
+
+    assert!(
+        state_path.exists(),
+        "sync state should remain available for continue or reset"
+    );
+}
+
+#[test]
 fn status_discovers_linear_stack_in_order() {
     let (_temp, mut cmd) = stck_cmd_with_stubbed_tools();
     cmd.arg("status");


### PR DESCRIPTION
## Summary

Make `stck sync` require an explicit recovery choice after a failed rebase.

This change stops plain `stck sync` from silently advancing past a failed step and tells the user to choose between `stck sync --continue` and `stck sync --reset` instead. Stack position: base `main`; child PR: #32 `Fail Closed When Parent Discovery Errors`.

## Changelist

- `src/cli.rs` Stop plain `stck sync` from auto-advancing failed sync state and return a clear remediation message instead.
- `tests/cli_skeleton.rs` Add a regression test for the plain-retry path and preserve coverage for the existing `--continue` and `--reset` flows.

## Checklist

- [x] Changes are minimal and focused for this milestone
- [x] No breaking CLI changes unless explicitly intended
- [x] Errors are user-facing, actionable, and prefixed with `error:`
- [x] Added/updated tests for behavior changes
- [ ] Updated docs/plan if behavior or scope changed
