### PR TITLE
Fail Closed When Parent Discovery Errors

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -304,14 +304,16 @@ fn run_new(preflight: &env::PreflightContext, new_branch: &str) -> ExitCode {
 }
 
 /// Discover the correct PR base for a bootstrap PR by finding the nearest
-/// ancestor branch that has an open PR. Falls back to `default_branch`.
+/// ancestor branch that has an open PR. Falls back to `default_branch` only
+/// when no suitable ancestor PR is found.
 fn discover_parent_base(branch: &str, default_branch: &str) -> Result<String, String> {
     // Find all open PRs whose head branch is a git ancestor of `branch`.
     // The closest ancestor (by commit distance) wins.
-    let prs = match github::list_open_prs() {
-        Ok(prs) => prs,
-        Err(_) => return Ok(default_branch.to_string()),
-    };
+    let prs = github::list_open_prs().map_err(|message| {
+        format!(
+            "could not auto-detect stack parent for {branch}: {message}; retry or pass `--base <branch>` explicitly"
+        )
+    })?;
 
     let branch_ref = format!("refs/heads/{branch}");
     let mut best: Option<&str> = None;

--- a/tests/cli_skeleton.rs
+++ b/tests/cli_skeleton.rs
@@ -663,6 +663,17 @@ fn new_from_stacked_branch_discovers_parent_base() {
 }
 
 #[test]
+fn new_fails_when_parent_discovery_errors() {
+    let (_temp, mut cmd) = stck_cmd_with_stubbed_tools();
+    cmd.env("STCK_TEST_PR_LIST_FAIL", "1");
+    cmd.args(["new", "feature-next"]);
+
+    cmd.assert().code(1).stderr(predicate::str::contains(
+        "error: could not auto-detect stack parent for feature-branch: failed to list open pull requests from GitHub; stderr: failed to list pull requests; retry or pass `--base <branch>` explicitly",
+    ));
+}
+
+#[test]
 fn submit_creates_pr_with_base_override() {
     let (_temp, mut cmd) = stck_cmd_with_stubbed_tools();
     let log_path = std::env::temp_dir().join("stck-submit-base-override.log");
@@ -716,6 +727,17 @@ fn submit_falls_back_to_default_when_no_parent_pr() {
         .stdout(predicate::str::contains(
             "$ gh pr create --base main --head feature-branch",
         ));
+}
+
+#[test]
+fn submit_fails_when_parent_discovery_errors() {
+    let (_temp, mut cmd) = stck_cmd_with_stubbed_tools();
+    cmd.env("STCK_TEST_PR_LIST_FAIL", "1");
+    cmd.arg("submit");
+
+    cmd.assert().code(1).stderr(predicate::str::contains(
+        "error: could not auto-detect stack parent for feature-branch: failed to list open pull requests from GitHub; stderr: failed to list pull requests; retry or pass `--base <branch>` explicitly",
+    ));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Fail closed when stack-parent auto-discovery cannot inspect open PRs.

This change turns GitHub lookup failures during parent discovery into explicit user-facing errors instead of silently defaulting to `main`, which could create the wrong PR relationship. Stack position: base PR #31 `Make Sync Retry Explicit`; child PR: #33 `Skip needs_push for Merged Branches`.

## Changelist

- `src/cli.rs` Propagate parent-discovery failures with guidance to retry or pass `--base` explicitly.
- `tests/cli_skeleton.rs` Add `new` and `submit` regression coverage for the `gh pr list` failure path while keeping the happy-path parent-detection tests intact.

## Checklist

- [x] Changes are minimal and focused for this milestone
- [x] No breaking CLI changes unless explicitly intended
- [x] Errors are user-facing, actionable, and prefixed with `error:`
- [x] Added/updated tests for behavior changes
- [ ] Updated docs/plan if behavior or scope changed
