### PR TITLE
Skip needs_push for Merged Branches

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -111,6 +111,10 @@ pub fn run() -> ExitCode {
                 }
             }
             for line in &mut report.lines {
+                if line.state == github::PrState::Merged {
+                    continue;
+                }
+
                 let needs_push = match gitops::branch_needs_push(&line.branch) {
                     Ok(needs_push) => needs_push,
                     Err(message) => {

--- a/tests/cli_skeleton.rs
+++ b/tests/cli_skeleton.rs
@@ -1575,6 +1575,22 @@ fn status_reports_needs_push_when_branch_diverges_from_origin() {
 }
 
 #[test]
+fn status_skips_needs_push_for_merged_branches() {
+    let (_temp, mut cmd) = stck_cmd_with_stubbed_tools();
+    cmd.env("STCK_TEST_MISSING_REMOTE_BRANCH", "feature-base");
+    cmd.arg("status");
+
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "feature-base PR #100 MERGED base=main",
+        ))
+        .stdout(predicate::str::contains(
+            "Summary: 1 needs_sync, 0 needs_push, 0 base_mismatch",
+        ));
+}
+
+#[test]
 fn status_reports_needs_sync_when_default_branch_has_advanced() {
     let (_temp, mut cmd) = stck_cmd_with_stubbed_tools();
     cmd.env("STCK_TEST_SYNC_NOOP", "1");


### PR DESCRIPTION
## Summary

Skip `needs_push` status checks for merged PR branches.

This change makes `stck status` match what `stck push` actually does by avoiding `needs_push` flags on merged ancestors that will never be pushed. Stack position: base PR #32 `Fail Closed When Parent Discovery Errors`; child PR: #34 `Guard Fresh Sync Runs From Active Rebases`.

## Changelist

- `src/cli.rs` Skip push-divergence checks for merged PR lines in `status` output.
- `tests/cli_skeleton.rs` Add a regression test covering the merged-ancestor case and keep the existing divergent-open-branch status test passing.

## Checklist

- [x] Changes are minimal and focused for this milestone
- [x] No breaking CLI changes unless explicitly intended
- [x] Errors are user-facing, actionable, and prefixed with `error:`
- [x] Added/updated tests for behavior changes
- [ ] Updated docs/plan if behavior or scope changed
