### PR TITLE
Guard Fresh Sync Runs From Active Rebases

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -460,6 +460,20 @@ fn run_sync(preflight: &env::PreflightContext, continue_sync: bool, reset_sync: 
                 return ExitCode::from(1);
             }
 
+            let rebase_in_progress = match gitops::rebase_in_progress() {
+                Ok(in_progress) => in_progress,
+                Err(message) => {
+                    eprintln!("error: {message}");
+                    return ExitCode::from(1);
+                }
+            };
+            if rebase_in_progress {
+                eprintln!(
+                    "error: rebase is already in progress; run `git rebase --continue` or `git rebase --abort` before starting a new `stck sync`"
+                );
+                return ExitCode::from(1);
+            }
+
             if let Err(message) = gitops::fetch_origin() {
                 eprintln!("error: {message}");
                 return ExitCode::from(1);

--- a/tests/cli_skeleton.rs
+++ b/tests/cli_skeleton.rs
@@ -1279,6 +1279,18 @@ fn sync_continue_requires_existing_state() {
 }
 
 #[test]
+fn sync_fails_early_when_rebase_is_already_in_progress() {
+    let (temp, mut cmd) = stck_cmd_with_stubbed_tools();
+    fs::create_dir_all(temp.path().join("git-dir").join("rebase-merge"))
+        .expect("rebase-merge dir should be created");
+    cmd.arg("sync");
+
+    cmd.assert().code(1).stderr(predicate::str::contains(
+        "error: rebase is already in progress; run `git rebase --continue` or `git rebase --abort` before starting a new `stck sync`",
+    ));
+}
+
+#[test]
 fn sync_rejects_continue_and_reset_together() {
     let (_temp, mut cmd) = stck_cmd_with_stubbed_tools();
     cmd.args(["sync", "--continue", "--reset"]);


### PR DESCRIPTION
## Summary

Guard fresh `stck sync` runs when a Git rebase is already in progress.

This change adds an early preflight check on the fresh sync path so we fail fast with recovery guidance instead of colliding with an unrelated/manual rebase later in the workflow. Stack position: base PR #33 `Skip needs_push for Merged Branches`; no child PR in this stack yet.

## Changelist

- `src/cli.rs` Check for an existing rebase before planning a new sync run and emit a dedicated error message.
- `tests/cli_skeleton.rs` Add coverage for the fresh-run rebase-in-progress case and keep the existing sync resume/reset behavior tests green.

## Checklist

- [x] Changes are minimal and focused for this milestone
- [x] No breaking CLI changes unless explicitly intended
- [x] Errors are user-facing, actionable, and prefixed with `error:`
- [x] Added/updated tests for behavior changes
- [ ] Updated docs/plan if behavior or scope changed
