### PR TITLE
Skip Already-Satisfied Push Retargets

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -724,6 +724,7 @@ fn run_push(preflight: &env::PreflightContext) -> ExitCode {
             } else {
                 stack::build_push_retargets(&stack, &preflight.default_branch)
             };
+            let retargets = stack::filter_pending_retargets(retargets, &stack);
             let mut push_branches = Vec::new();
             for branch in stack::build_push_branches(&stack) {
                 let needs_push = match gitops::branch_needs_push(&branch) {

--- a/src/stack.rs
+++ b/src/stack.rs
@@ -164,11 +164,26 @@ pub fn build_push_retargets(stack: &[PullRequest], default_branch: &str) -> Vec<
         .collect()
 }
 
+pub fn filter_pending_retargets(
+    retargets: Vec<RetargetStep>,
+    stack: &[PullRequest],
+) -> Vec<RetargetStep> {
+    retargets
+        .into_iter()
+        .filter(
+            |retarget| match stack.iter().find(|pr| pr.head_ref_name == retarget.branch) {
+                Some(pr) => pr.base_ref_name != retarget.new_base_ref,
+                None => true,
+            },
+        )
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
         build_push_branches, build_push_retargets, build_status_report, build_sync_plan,
-        first_open_branch_rooted_on_default, RetargetStep, SyncStep,
+        filter_pending_retargets, first_open_branch_rooted_on_default, RetargetStep, SyncStep,
     };
     use crate::github::{PrState, PullRequest};
 
@@ -394,6 +409,38 @@ mod tests {
             vec![RetargetStep {
                 branch: "feature-c".to_string(),
                 new_base_ref: "main".to_string(),
+            }]
+        );
+    }
+
+    #[test]
+    fn filter_pending_retargets_skips_branches_already_on_target_base() {
+        let stack = vec![
+            pr(101, "feature-b", "main", PrState::Open),
+            pr(102, "feature-c", "feature-b", PrState::Open),
+        ];
+        let retargets = vec![
+            RetargetStep {
+                branch: "feature-b".to_string(),
+                new_base_ref: "main".to_string(),
+            },
+            RetargetStep {
+                branch: "feature-c".to_string(),
+                new_base_ref: "feature-b".to_string(),
+            },
+            RetargetStep {
+                branch: "feature-d".to_string(),
+                new_base_ref: "feature-c".to_string(),
+            },
+        ];
+
+        let pending = filter_pending_retargets(retargets, &stack);
+
+        assert_eq!(
+            pending,
+            vec![RetargetStep {
+                branch: "feature-d".to_string(),
+                new_base_ref: "feature-c".to_string(),
             }]
         );
     }

--- a/tests/cli_skeleton.rs
+++ b/tests/cli_skeleton.rs
@@ -380,6 +380,10 @@ if [[ "${1:-}" == "pr" && "${2:-}" == "list" ]]; then
       echo '[{"number":102,"headRefName":"feature-child-a","baseRefName":"feature-branch","state":"OPEN"},{"number":103,"headRefName":"feature-child-b","baseRefName":"feature-branch","state":"OPEN"}]'
       exit 0
     fi
+    if [[ -n "${STCK_TEST_FEATURE_CHILD_BASE:-}" && "${pr_list_base}" == "feature-branch" ]]; then
+      echo "[{\"number\":102,\"headRefName\":\"feature-child\",\"baseRefName\":\"${STCK_TEST_FEATURE_CHILD_BASE}\",\"state\":\"OPEN\"}]"
+      exit 0
+    fi
     if [[ "${STCK_TEST_SYNC_NOOP:-0}" == "1" ]]; then
       case "${pr_list_base}" in
         main) echo '[{"number":100,"headRefName":"feature-base","baseRefName":"main","state":"OPEN"}]' ;;
@@ -423,6 +427,16 @@ if [[ "${1:-}" == "pr" && "${2:-}" == "view" ]]; then
     if [[ "${STCK_TEST_MISSING_CURRENT_PR:-0}" == "1" && "${branch}" == "feature-branch" ]]; then
       echo "no pull requests found for branch ${branch}" >&2
       exit 1
+    fi
+
+    if [[ -n "${STCK_TEST_FEATURE_BRANCH_BASE:-}" && "${branch}" == "feature-branch" ]]; then
+      echo "{\"number\":101,\"headRefName\":\"feature-branch\",\"baseRefName\":\"${STCK_TEST_FEATURE_BRANCH_BASE}\",\"state\":\"OPEN\"}"
+      exit 0
+    fi
+
+    if [[ -n "${STCK_TEST_FEATURE_CHILD_BASE:-}" && "${branch}" == "feature-child" ]]; then
+      echo "{\"number\":102,\"headRefName\":\"feature-child\",\"baseRefName\":\"${STCK_TEST_FEATURE_CHILD_BASE}\",\"state\":\"OPEN\"}"
+      exit 0
     fi
 
     if [[ "${STCK_TEST_NON_LINEAR:-0}" == "1" ]]; then
@@ -931,11 +945,9 @@ fn push_executes_pushes_before_retargets_and_prints_summary() {
         .stdout(predicate::str::contains(
             "$ gh pr edit feature-branch --base main",
         ))
+        .stdout(predicate::str::contains("$ gh pr edit feature-child --base feature-branch").not())
         .stdout(predicate::str::contains(
-            "$ gh pr edit feature-child --base feature-branch",
-        ))
-        .stdout(predicate::str::contains(
-            "Push succeeded. Pushed 2 branch(es) and applied 2 PR base update(s) in this run.",
+            "Push succeeded. Pushed 2 branch(es) and applied 1 PR base update(s) in this run.",
         ));
 
     let log = fs::read_to_string(&log_path).expect("push log should exist");
@@ -996,6 +1008,7 @@ fn push_resumes_after_partial_retarget_failure() {
         "STCK_TEST_NEEDS_PUSH_BRANCHES",
         "feature-branch,feature-child",
     );
+    first.env("STCK_TEST_FEATURE_CHILD_BASE", "main");
     first.env("STCK_TEST_RETARGET_FAIL_ONCE_FILE", marker_path.as_os_str());
     first.env("STCK_TEST_RETARGET_FAIL_ONCE_BRANCH", "feature-child");
     first.arg("push");
@@ -1024,6 +1037,7 @@ fn push_resumes_after_partial_retarget_failure() {
         "STCK_TEST_NEEDS_PUSH_BRANCHES",
         "feature-branch,feature-child",
     );
+    resume.env("STCK_TEST_FEATURE_CHILD_BASE", "main");
     resume.arg("push");
 
     resume
@@ -1093,10 +1107,66 @@ fn push_uses_cached_sync_plan_retargets_when_available() {
         .stdout(predicate::str::contains(
             "$ gh pr edit feature-branch --base main",
         ))
+        .stdout(predicate::str::contains("$ gh pr edit feature-child --base feature-branch").not())
         .stdout(predicate::str::contains(
-            "$ gh pr edit feature-child --base feature-branch",
+            "Push succeeded. Pushed 2 branch(es) and applied 1 PR base update(s) in this run.",
         ));
 
+    assert!(
+        !cached_plan_path.exists(),
+        "push should clear cached sync plan after success"
+    );
+}
+
+#[test]
+fn push_skips_cached_sync_plan_retargets_that_are_already_satisfied() {
+    let (temp, mut sync) = stck_cmd_with_stubbed_tools();
+    let log_path = temp.path().join("push-cached-plan-noop-retargets.log");
+    let _ = fs::remove_file(&log_path);
+
+    sync.env("STCK_TEST_LOG", log_path.as_os_str());
+    sync.env(
+        "STCK_TEST_NEEDS_PUSH_BRANCHES",
+        "feature-branch,feature-child",
+    );
+    sync.arg("sync");
+    sync.assert().success();
+
+    let cached_plan_path = temp
+        .path()
+        .join("git-dir")
+        .join("stck")
+        .join("last-sync-plan.json");
+    assert!(
+        cached_plan_path.exists(),
+        "sync should persist cached sync plan"
+    );
+
+    let mut push = stck_cmd();
+    let path = std::env::var("PATH").expect("PATH should be set");
+    let full_path = format!("{}:{}", temp.path().join("bin").display(), path);
+    push.env("PATH", full_path);
+    push.env("STCK_TEST_GIT_DIR", temp.path().join("git-dir").as_os_str());
+    push.env("STCK_TEST_LOG", log_path.as_os_str());
+    push.env(
+        "STCK_TEST_NEEDS_PUSH_BRANCHES",
+        "feature-branch,feature-child",
+    );
+    push.env("STCK_TEST_FEATURE_BRANCH_BASE", "main");
+    push.arg("push");
+
+    push.assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "Push succeeded. Pushed 2 branch(es) and applied 0 PR base update(s) in this run.",
+        ))
+        .stdout(predicate::str::contains("$ gh pr edit").not());
+
+    let log = fs::read_to_string(&log_path).expect("push log should exist");
+    assert!(
+        !log.contains("pr edit"),
+        "push should skip retarget calls when cached plan bases are already satisfied"
+    );
     assert!(
         !cached_plan_path.exists(),
         "push should clear cached sync plan after success"
@@ -1112,7 +1182,7 @@ fn push_skips_branches_without_local_changes() {
     cmd.arg("push");
 
     cmd.assert().success().stdout(predicate::str::contains(
-        "Push succeeded. Pushed 0 branch(es) and applied 2 PR base update(s) in this run.",
+        "Push succeeded. Pushed 0 branch(es) and applied 1 PR base update(s) in this run.",
     ));
 
     let log = fs::read_to_string(&log_path).expect("push log should exist");
@@ -1783,8 +1853,9 @@ fn sync_then_push_after_squash_merge_produces_correct_retargets() {
         .stdout(predicate::str::contains(
             "$ gh pr edit feature-branch --base main",
         ))
+        .stdout(predicate::str::contains("$ gh pr edit feature-child --base feature-branch").not())
         .stdout(predicate::str::contains(
-            "$ gh pr edit feature-child --base feature-branch",
+            "Push succeeded. Pushed 2 branch(es) and applied 1 PR base update(s) in this run.",
         ));
 }
 


### PR DESCRIPTION
## Summary

Skip PR retarget calls during `stck push` when the current GitHub base already matches the desired base.

This keeps `push` from doing redundant `gh pr edit` calls after a sync and rewrite flow, which is the dogfooded case that left branch pushes successful but the command blocked by stale push state. The implementation trims cached or computed retargets against the currently discovered stack before fresh push state is saved.

## Changelist

- `src/cli.rs`: Filter planned retargets against the currently discovered stack before saving fresh push state.
- `src/stack.rs`: Add a helper that drops retarget steps whose PR base already matches the desired target.
- `tests/cli_skeleton.rs`: Add regression coverage for cached no-op retargets and update push expectations to reflect that only unsatisfied retargets should run.

## Checklist

- [x] Changes are minimal and focused for this milestone
- [x] No breaking CLI changes unless explicitly intended
- [x] Errors are user-facing, actionable, and prefixed with `error:`
- [x] Added/updated tests for behavior changes
- [ ] Updated docs/plan if behavior or scope changed