### PR TITLE
Reconcile Saved Push Retargets on Resume

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -696,7 +696,33 @@ fn run_push(preflight: &env::PreflightContext) -> ExitCode {
     };
 
     let mut state = match existing_state {
-        Some(state) => state,
+        Some(mut state) => {
+            if state.completed_retargets < state.retargets.len() {
+                let stack = match github::discover_linear_stack(
+                    &preflight.current_branch,
+                    &preflight.default_branch,
+                ) {
+                    Ok(stack) => stack,
+                    Err(message) => {
+                        eprintln!("error: {message}");
+                        return ExitCode::from(1);
+                    }
+                };
+
+                state.retargets = stack::filter_pending_retargets(
+                    state.retargets[state.completed_retargets..].to_vec(),
+                    &stack,
+                );
+                state.completed_retargets = 0;
+
+                if let Err(message) = sync_state::save_push(&state) {
+                    eprintln!("error: {message}");
+                    return ExitCode::from(1);
+                }
+            }
+
+            state
+        }
         None => {
             let stack = match github::discover_linear_stack(
                 &preflight.current_branch,

--- a/tests/cli_skeleton.rs
+++ b/tests/cli_skeleton.rs
@@ -1174,6 +1174,71 @@ fn push_skips_cached_sync_plan_retargets_that_are_already_satisfied() {
 }
 
 #[test]
+fn push_resume_clears_stale_state_when_remaining_retargets_are_already_satisfied() {
+    let (temp, mut push) = stck_cmd_with_stubbed_tools();
+    let log_path = temp.path().join("push-resume-stale-state.log");
+    let _ = fs::remove_file(&log_path);
+
+    let stck_dir = temp.path().join("git-dir").join("stck");
+    fs::create_dir_all(&stck_dir).expect("stck state dir should exist");
+    let state_path = stck_dir.join("last-plan.json");
+    fs::write(
+        &state_path,
+        r#"{
+  "kind": "push",
+  "push_branches": ["feature-branch", "feature-child"],
+  "completed_pushes": 2,
+  "retargets": [
+    {"branch": "feature-branch", "new_base_ref": "main"},
+    {"branch": "feature-child", "new_base_ref": "feature-branch"}
+  ],
+  "completed_retargets": 0
+}"#,
+    )
+    .expect("push state should be written");
+
+    let cached_plan_path = stck_dir.join("last-sync-plan.json");
+    fs::write(
+        &cached_plan_path,
+        r#"{
+  "default_branch": "main",
+  "retargets": [
+    {"branch": "feature-branch", "new_base_ref": "main"},
+    {"branch": "feature-child", "new_base_ref": "feature-branch"}
+  ]
+}"#,
+    )
+    .expect("cached sync plan should be written");
+
+    push.env("STCK_TEST_LOG", log_path.as_os_str());
+    push.env("STCK_TEST_FEATURE_BRANCH_BASE", "main");
+    push.arg("push");
+
+    push.assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "Push succeeded. Pushed 0 branch(es) and applied 0 PR base update(s) in this run.",
+        ))
+        .stdout(predicate::str::contains("$ gh pr edit").not());
+
+    if log_path.exists() {
+        let log = fs::read_to_string(&log_path).expect("push log should be readable");
+        assert!(
+            !log.contains("pr edit"),
+            "resume should skip retarget calls when saved retargets are already satisfied"
+        );
+    }
+    assert!(
+        !state_path.exists(),
+        "push state should be cleared after a no-op resume succeeds"
+    );
+    assert!(
+        !cached_plan_path.exists(),
+        "cached sync plan should be cleared after a no-op resume succeeds"
+    );
+}
+
+#[test]
 fn push_skips_branches_without_local_changes() {
     let (_temp, mut cmd) = stck_cmd_with_stubbed_tools();
     let log_path = std::env::temp_dir().join("stck-push-no-divergence.log");


### PR DESCRIPTION
## Summary

Re-check saved `stck push` retargets against the current PR bases when resuming an interrupted push.

This fixes the dogfooded case where branch pushes had already succeeded and PR bases were already correct, but stale push state still blocked later `sync` runs. On resume, `push` now trims the saved retarget list down to only still-unsatisfied base updates, so it can either finish the remaining real work or clear itself as a successful no-op.

## Changelist

- `src/cli.rs`: Reconcile saved retarget steps against the currently discovered stack before executing a resumed push.
- `tests/cli_skeleton.rs`: Add regression coverage for stale saved push state with already-satisfied retargets, and keep the existing partial-failure resume path covered.

## Checklist

- [x] Changes are minimal and focused for this milestone
- [x] No breaking CLI changes unless explicitly intended
- [x] Errors are user-facing, actionable, and prefixed with `error:`
- [x] Added/updated tests for behavior changes
- [ ] Updated docs/plan if behavior or scope changed