### PR TITLE
Add MSRV Metadata and Refresh Docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,6 +11,8 @@ cargo test --all-features
 cargo build --all-features
 ```
 
+The crate currently declares Rust `1.74` as its minimum supported toolchain in `Cargo.toml`.
+
 ## Scope
 
 - Keep changes minimal and focused.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "stck"
 version = "0.1.2"
 edition = "2021"
+rust-version = "1.74"
 license = "MIT"
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Stacked PRs improve review quality and throughput, but day-to-day maintenance ca
 
 ## Status
 
-First public release (`v0.1.0`).
+Early public release series (`v0.1.x`).
 
 ## Basic Usage
 
@@ -23,6 +23,8 @@ stck push
 ```
 
 `stck new <branch>` works both when starting from the default branch and when stacking on top of an existing branch.
+
+`stck submit` auto-detects the most likely stack parent when `--base` is omitted. If discovery succeeds but finds no parent PR, it falls back to the repository default branch. In larger repositories, discovery currently inspects up to the first 100 open PRs, so `--base <branch>` remains the reliable escape hatch.
 
 Git subcommand entrypoint is also installed (when installed via homebrew):
 
@@ -53,6 +55,8 @@ git stck --help
 cargo build --release --all-features
 ./target/release/stck --help
 ```
+
+Source builds currently target Rust `1.74` or newer.
 
 Homebrew release details are documented in [`docs/release-homebrew.md`](./docs/release-homebrew.md).
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -72,8 +72,11 @@ stck submit --base feature-a
 
 `submit` creates a PR for the current branch when one does not exist.
 
-- If no `--base` is provided, it defaults to the repository default branch.
-- Use `--base` to target a stack parent branch explicitly.
+- If no `--base` is provided, `stck` first tries to auto-detect the stack parent from open PR metadata.
+- If discovery succeeds but finds no parent PR, `stck` falls back to the repository default branch.
+- If GitHub lookup fails, `stck` errors and tells you to retry or pass `--base <branch>` explicitly.
+- Parent auto-discovery currently inspects up to the first 100 open PRs, so `--base` is the reliable override in larger repositories.
+- Use `--base` any time you want to target a stack parent branch explicitly.
 - If the current branch already has a PR, it reports a no-op.
 
 ### 3. Sync local stack after upstream changes
@@ -128,5 +131,6 @@ stck push
 
 ## Notes
 
-- `stck` assumes a linear stack in `v0.1.0` and fails fast for non-linear graphs.
+- `stck` currently assumes a linear stack and fails fast for non-linear graphs.
+- Parent auto-discovery for `new`/`submit` currently scans up to 100 open PRs before giving up. In larger repositories, pass `--base <branch>` explicitly.
 - If a rebase conflict happens during `sync`, resolve conflicts with normal Git workflow, then continue and rerun `stck sync` as needed.

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,5 @@
+#![forbid(unsafe_code)]
+
 mod cli;
 mod env;
 mod github;


### PR DESCRIPTION
## Summary

Add explicit release-hygiene metadata and refresh the user-facing docs to match current `stck` behavior.

This groups together a few small but related cleanup tasks: declare an MSRV in `Cargo.toml`, forbid `unsafe` at the crate root, stop the docs from hard-coding the project as `v0.1.0`, and document the current parent auto-discovery behavior and 100-open-PR limit for `new` / `submit`.

## Changelist

- `Cargo.toml`: Declare Rust `1.74` as the minimum supported toolchain.
- `src/main.rs`: Add `#![forbid(unsafe_code)]` at the crate root.
- `README.md`: Refresh release/status wording, note the current `submit` auto-detection behavior, and mention the MSRV.
- `USAGE.md`: Document `submit` parent auto-detection, the fail-closed GitHub lookup behavior, and the current 100-open-PR discovery limit.
- `CONTRIBUTING.md`: Note the declared MSRV for contributors.

## Checklist

- [x] Changes are minimal and focused for this milestone
- [x] No breaking CLI changes unless explicitly intended
- [x] Errors are user-facing, actionable, and prefixed with `error:`
- [x] Added/updated tests for behavior changes
- [x] Updated docs/plan if behavior or scope changed