### PR TITLE
Add a Clap Definition Smoke Test

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -861,3 +861,14 @@ fn run_push(preflight: &env::PreflightContext) -> ExitCode {
     );
     ExitCode::SUCCESS
 }
+
+#[cfg(test)]
+mod tests {
+    use super::Cli;
+    use clap::CommandFactory;
+
+    #[test]
+    fn clap_definition_debug_asserts() {
+        Cli::command().debug_assert();
+    }
+}


### PR DESCRIPTION
## Summary

Add a dedicated clap smoke test that runs `Cli::command().debug_assert()`.

This is a very small guardrail, but it is high-signal for CLI tooling: it catches clap definition wiring mistakes early and gives us a focused failure if command metadata drifts in a way integration tests do not cover directly.

## Changelist

- `src/cli.rs`: Add a local `#[cfg(test)]` module with a `Cli::command().debug_assert()` smoke test.

## Checklist

- [x] Changes are minimal and focused for this milestone
- [x] No breaking CLI changes unless explicitly intended
- [x] Errors are user-facing, actionable, and prefixed with `error:`
- [x] Added/updated tests for behavior changes
- [ ] Updated docs/plan if behavior or scope changed