### PR TITLE
Add real Git integration coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,10 +31,27 @@ jobs:
         run: cargo fmt --all --check
 
       - name: Lint
-        run: cargo clippy --all-targets --all-features -- -D warnings
+        run: cargo clippy --locked --all-targets --all-features -- -D warnings
 
       - name: Test
-        run: cargo test --all-features
+        run: cargo test --locked --all-features
 
       - name: Build
-        run: cargo build --all-features
+        run: cargo build --locked --all-features
+
+  msrv:
+    name: Minimum Rust 1.95
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust 1.95
+        uses: dtolnay/rust-toolchain@1.95.0
+
+      - name: Cache Rust build artifacts
+        uses: Swatinem/rust-cache@v2
+
+      - name: Check all targets
+        run: cargo check --locked --all-targets --all-features

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
           fi
 
       - name: Build release binary
-        run: cargo build --release --all-features
+        run: cargo build --locked --release --all-features
 
       - name: Package artifact
         shell: bash

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,13 +5,15 @@ Use standard Cargo tooling for formatting, linting, tests, and build checks.
 ## Local Validation
 
 ```bash
-cargo fmt --all
-cargo clippy --all-targets --all-features -- -D warnings
-cargo test --all-features
-cargo build --all-features
+cargo fmt --all --check
+cargo clippy --locked --all-targets --all-features -- -D warnings
+cargo test --locked --all-features
+cargo build --locked --all-features
 ```
 
-The crate currently declares Rust `1.74` as its minimum supported toolchain in `Cargo.toml`.
+The project supports the current stable Rust release and the two preceding
+releases (N-2). The minimum is declared in `Cargo.toml`, and CI validates both
+that version and the current stable toolchain.
 
 ## Scope
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -478,7 +478,7 @@ dependencies = [
 
 [[package]]
 name = "stck"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "assert_cmd",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,8 @@
 name = "stck"
 version = "0.1.4"
 edition = "2021"
-rust-version = "1.74"
+rust-version = "1.95"
+resolver = "3"
 license = "MIT"
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -52,11 +52,12 @@ git stck --help
 ### From source
 
 ```bash
-cargo build --release --all-features
+cargo build --locked --release --all-features
 ./target/release/stck --help
 ```
 
-Source builds currently target Rust `1.74` or newer.
+`stck` supports the current stable Rust release and the two preceding releases
+(N-2). The current minimum supported Rust version is `1.95`.
 
 Homebrew release details are documented in [`docs/release-homebrew.md`](./docs/release-homebrew.md).
 

--- a/tests/harness/mod.rs
+++ b/tests/harness/mod.rs
@@ -5,6 +5,7 @@ use assert_cmd::Command;
 use std::fs;
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
+use std::process::{Command as StdCommand, Output};
 use tempfile::TempDir;
 
 pub fn stck_cmd() -> Command {
@@ -576,4 +577,303 @@ pub fn stck_cmd_with_stubbed_tools() -> (TempDir, Command) {
 
 pub fn log_path(temp: &TempDir, name: &str) -> PathBuf {
     temp.path().join(name)
+}
+
+/// A temporary repository that runs the real `git` binary against a local
+/// bare `origin`, while keeping all GitHub interactions offline through a
+/// configurable `gh` stub.
+pub struct RealGitRepo {
+    _temp: TempDir,
+    worktree: PathBuf,
+    remote: PathBuf,
+    bin_dir: PathBuf,
+    gh_responses: PathBuf,
+    gh_log: PathBuf,
+    global_git_config: PathBuf,
+}
+
+impl RealGitRepo {
+    pub fn new() -> Self {
+        let temp = TempDir::new().expect("real-git tempdir should be created");
+        let worktree = temp.path().join("worktree");
+        let remote = temp.path().join("origin.git");
+        let bin_dir = temp.path().join("bin");
+        let gh_responses = temp.path().join("gh-responses");
+        let gh_log = temp.path().join("gh.log");
+        let global_git_config = temp.path().join("global.gitconfig");
+
+        fs::create_dir_all(&bin_dir).expect("real-git bin dir should be created");
+        fs::create_dir_all(&gh_responses).expect("real-git gh response dir should be created");
+        fs::write(&gh_log, "").expect("real-git gh log should be initialized");
+        fs::write(&global_git_config, "")
+            .expect("isolated global git config should be initialized");
+
+        write_stub(
+            &bin_dir.join("gh"),
+            r#"#!/usr/bin/env bash
+set -euo pipefail
+
+printf '%s\n' "$*" >> "${STCK_REAL_GH_LOG}"
+
+if [[ "${1:-}" == "--version" ]]; then
+  echo "gh version 2.0.0"
+  exit 0
+fi
+
+if [[ "${1:-}" == "auth" && "${2:-}" == "status" ]]; then
+  exit 0
+fi
+
+if [[ "${1:-}" == "repo" && "${2:-}" == "view" ]]; then
+  echo "main"
+  exit 0
+fi
+
+if [[ "${1:-}" == "pr" && "${2:-}" == "view" ]]; then
+  branch="${3:-}"
+  safe_branch="${branch//\//__}"
+  response="${STCK_REAL_GH_RESPONSES}/pr-view-${safe_branch}.json"
+  if [[ -f "${response}" ]]; then
+    cat "${response}"
+    exit 0
+  fi
+  echo "no pull requests found for branch ${branch}" >&2
+  exit 1
+fi
+
+if [[ "${1:-}" == "pr" && "${2:-}" == "list" ]]; then
+  base=""
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --base) base="${2:-}"; shift 2 ;;
+      *) shift ;;
+    esac
+  done
+
+  if [[ -n "${base}" ]]; then
+    safe_base="${base//\//__}"
+    response="${STCK_REAL_GH_RESPONSES}/pr-list-base-${safe_base}.json"
+  else
+    response="${STCK_REAL_GH_RESPONSES}/pr-list-open.json"
+  fi
+
+  if [[ -f "${response}" ]]; then
+    cat "${response}"
+  else
+    echo "[]"
+  fi
+  exit 0
+fi
+
+if [[ "${1:-}" == "pr" && ( "${2:-}" == "create" || "${2:-}" == "edit" ) ]]; then
+  exit 0
+fi
+
+echo "unsupported gh invocation: $*" >&2
+exit 1
+"#,
+        );
+
+        let remote_arg = remote.to_string_lossy().into_owned();
+        let worktree_arg = worktree.to_string_lossy().into_owned();
+        assert_git_success(
+            temp.path(),
+            &global_git_config,
+            &["init", "--bare", &remote_arg],
+        );
+        assert_git_success(
+            temp.path(),
+            &global_git_config,
+            &[
+                "--git-dir",
+                &remote_arg,
+                "symbolic-ref",
+                "HEAD",
+                "refs/heads/main",
+            ],
+        );
+        assert_git_success(temp.path(), &global_git_config, &["init", &worktree_arg]);
+
+        let repo = Self {
+            _temp: temp,
+            worktree,
+            remote,
+            bin_dir,
+            gh_responses,
+            gh_log,
+            global_git_config,
+        };
+
+        let hooks_dir = repo.worktree.join(".git").join("test-hooks");
+        fs::create_dir_all(&hooks_dir).expect("isolated hooks dir should be created");
+        let hooks_arg = hooks_dir.to_string_lossy().into_owned();
+        let remote_arg = repo.remote.to_string_lossy().into_owned();
+
+        repo.git_success(&["symbolic-ref", "HEAD", "refs/heads/main"]);
+        repo.git_success(&["config", "user.name", "stck test"]);
+        repo.git_success(&["config", "user.email", "stck-test@example.com"]);
+        repo.git_success(&["config", "commit.gpgsign", "false"]);
+        repo.git_success(&["config", "core.hooksPath", &hooks_arg]);
+        repo.git_success(&["remote", "add", "origin", &remote_arg]);
+
+        fs::write(repo.worktree.join("README.md"), "initial\n")
+            .expect("initial repository file should be written");
+        repo.git_success(&["add", "README.md"]);
+        repo.git_success(&["commit", "-m", "Initial commit"]);
+        repo.git_success(&["push", "-u", "origin", "main"]);
+
+        repo
+    }
+
+    pub fn stck_cmd(&self) -> Command {
+        let mut paths = vec![self.bin_dir.clone()];
+        paths.extend(std::env::split_paths(
+            &std::env::var_os("PATH").expect("PATH should be set"),
+        ));
+        let path = std::env::join_paths(paths).expect("test PATH should be valid");
+
+        let mut cmd = stck_cmd();
+        cmd.current_dir(&self.worktree);
+        cmd.env("PATH", path);
+        cmd.env("GIT_CONFIG_GLOBAL", &self.global_git_config);
+        cmd.env("GIT_CONFIG_NOSYSTEM", "1");
+        cmd.env("STCK_REAL_GH_LOG", &self.gh_log);
+        cmd.env("STCK_REAL_GH_RESPONSES", &self.gh_responses);
+        cmd.env_remove("GIT_DIR");
+        cmd.env_remove("GIT_WORK_TREE");
+        cmd
+    }
+
+    pub fn create_branch(&self, branch: &str) {
+        self.git_success(&["checkout", "-b", branch]);
+    }
+
+    pub fn checkout(&self, branch: &str) {
+        self.git_success(&["checkout", branch]);
+    }
+
+    pub fn commit_file(&self, relative_path: &str, contents: &str, message: &str) {
+        let path = self.worktree.join(relative_path);
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).expect("commit file parent should be created");
+        }
+        fs::write(&path, contents).expect("commit file should be written");
+        self.git_success(&["add", "--", relative_path]);
+        self.git_success(&["commit", "-m", message]);
+    }
+
+    pub fn push(&self, branch: &str) {
+        self.git_success(&["push", "-u", "origin", branch]);
+    }
+
+    pub fn local_sha(&self, reference: &str) -> String {
+        self.git_stdout(&["rev-parse", reference])
+    }
+
+    pub fn remote_sha(&self, branch: &str) -> String {
+        let remote_arg = self.remote.to_string_lossy().into_owned();
+        let output = assert_git_success(
+            self._temp.path(),
+            &self.global_git_config,
+            &[
+                "--git-dir",
+                &remote_arg,
+                "rev-parse",
+                &format!("refs/heads/{branch}"),
+            ],
+        );
+        trimmed_stdout(output.stdout)
+    }
+
+    pub fn current_branch(&self) -> String {
+        self.git_stdout(&["branch", "--show-current"])
+    }
+
+    pub fn is_ancestor(&self, ancestor: &str, descendant: &str) -> bool {
+        let output = self.git_output(&["merge-base", "--is-ancestor", ancestor, descendant]);
+        match output.status.code() {
+            Some(0) => true,
+            Some(1) => false,
+            _ => panic!(
+                "git merge-base failed\nstdout: {}\nstderr: {}",
+                String::from_utf8_lossy(&output.stdout),
+                String::from_utf8_lossy(&output.stderr)
+            ),
+        }
+    }
+
+    pub fn write_pr_response(&self, branch: &str, json: &str) {
+        let branch = branch.replace('/', "__");
+        fs::write(
+            self.gh_responses.join(format!("pr-view-{branch}.json")),
+            json,
+        )
+        .expect("gh PR response should be written");
+    }
+
+    pub fn write_children_response(&self, base: &str, json: &str) {
+        let base = base.replace('/', "__");
+        fs::write(
+            self.gh_responses.join(format!("pr-list-base-{base}.json")),
+            json,
+        )
+        .expect("gh children response should be written");
+    }
+
+    pub fn gh_log(&self) -> String {
+        fs::read_to_string(&self.gh_log).expect("gh log should be readable")
+    }
+
+    fn git_stdout(&self, args: &[&str]) -> String {
+        trimmed_stdout(self.git_success(args).stdout)
+    }
+
+    fn git_success(&self, args: &[&str]) -> Output {
+        let output = self.git_output(args);
+        if !output.status.success() {
+            panic!(
+                "git {} failed\nstdout: {}\nstderr: {}",
+                args.join(" "),
+                String::from_utf8_lossy(&output.stdout),
+                String::from_utf8_lossy(&output.stderr)
+            );
+        }
+        output
+    }
+
+    fn git_output(&self, args: &[&str]) -> Output {
+        run_git(&self.worktree, &self.global_git_config, args)
+    }
+}
+
+fn assert_git_success(cwd: &Path, global_git_config: &Path, args: &[&str]) -> Output {
+    let output = run_git(cwd, global_git_config, args);
+    if !output.status.success() {
+        panic!(
+            "git {} failed\nstdout: {}\nstderr: {}",
+            args.join(" "),
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+    output
+}
+
+fn run_git(cwd: &Path, global_git_config: &Path, args: &[&str]) -> Output {
+    StdCommand::new("git")
+        .current_dir(cwd)
+        .env("GIT_CONFIG_GLOBAL", global_git_config)
+        .env("GIT_CONFIG_NOSYSTEM", "1")
+        .env_remove("GIT_DIR")
+        .env_remove("GIT_WORK_TREE")
+        .args(args)
+        .output()
+        .expect("git command should run")
+}
+
+fn trimmed_stdout(stdout: Vec<u8>) -> String {
+    String::from_utf8(stdout)
+        .expect("git stdout should be UTF-8")
+        .trim()
+        .to_string()
 }

--- a/tests/real_git.rs
+++ b/tests/real_git.rs
@@ -1,0 +1,116 @@
+mod harness;
+
+use harness::RealGitRepo;
+use predicates::prelude::*;
+
+#[test]
+fn new_creates_and_publishes_a_branch_with_real_git() {
+    let repo = RealGitRepo::new();
+    let mut cmd = repo.stck_cmd();
+    cmd.args(["new", "feature-new"]);
+
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("$ git checkout -b feature-new"))
+        .stdout(predicate::str::contains("$ git push -u origin feature-new"))
+        .stdout(predicate::str::contains(
+            "No branch-only commits in feature-new yet.",
+        ));
+
+    assert_eq!(repo.current_branch(), "feature-new");
+    assert_eq!(
+        repo.local_sha("refs/heads/feature-new"),
+        repo.remote_sha("feature-new")
+    );
+    assert!(
+        !repo.gh_log().contains("pr create"),
+        "new should wait for a branch-only commit before creating a PR"
+    );
+}
+
+#[test]
+fn submit_pushes_a_real_branch_before_creating_its_pr() {
+    let repo = RealGitRepo::new();
+    repo.create_branch("feature-submit");
+    repo.commit_file("feature.txt", "submitted\n", "Add submitted feature");
+
+    let mut cmd = repo.stck_cmd();
+    cmd.args(["submit", "--base", "main"]);
+
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "$ git push -u origin feature-submit",
+        ))
+        .stdout(predicate::str::contains(
+            "$ gh pr create --base main --head feature-submit",
+        ))
+        .stdout(predicate::str::contains(
+            "Created PR for feature-submit targeting main.",
+        ));
+
+    assert_eq!(
+        repo.local_sha("refs/heads/feature-submit"),
+        repo.remote_sha("feature-submit")
+    );
+    let gh_log = repo.gh_log();
+    assert!(gh_log.contains("pr view feature-submit --json number"));
+    assert!(gh_log.contains("pr create --base main --head feature-submit"));
+}
+
+#[test]
+fn sync_rebases_a_real_linear_stack_after_main_advances() {
+    let repo = RealGitRepo::new();
+
+    repo.create_branch("feature-base");
+    repo.commit_file("base.txt", "base\n", "Add base feature");
+    repo.push("feature-base");
+    let old_base_sha = repo.remote_sha("feature-base");
+
+    repo.create_branch("feature-child");
+    repo.commit_file("child.txt", "child\n", "Add child feature");
+    repo.push("feature-child");
+    let old_child_sha = repo.remote_sha("feature-child");
+
+    repo.checkout("main");
+    repo.commit_file("main.txt", "main advanced\n", "Advance main");
+    repo.push("main");
+    repo.checkout("feature-base");
+
+    repo.write_pr_response(
+        "feature-base",
+        r#"{"number":101,"headRefName":"feature-base","baseRefName":"main","state":"OPEN"}"#,
+    );
+    repo.write_pr_response(
+        "feature-child",
+        r#"{"number":102,"headRefName":"feature-child","baseRefName":"feature-base","state":"OPEN"}"#,
+    );
+    repo.write_children_response(
+        "feature-base",
+        r#"[{"number":102,"headRefName":"feature-child","baseRefName":"feature-base","state":"OPEN"}]"#,
+    );
+    repo.write_children_response("feature-child", "[]");
+
+    let mut cmd = repo.stck_cmd();
+    cmd.arg("sync");
+
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "$ git rebase --onto refs/remotes/origin/main",
+        ))
+        .stdout(predicate::str::contains(
+            "$ git rebase --onto refs/heads/feature-base",
+        ))
+        .stdout(predicate::str::contains(
+            "Sync succeeded locally. Run `stck push` to update remotes + PR bases.",
+        ));
+
+    assert_eq!(repo.current_branch(), "feature-base");
+    assert!(repo.is_ancestor("refs/remotes/origin/main", "refs/heads/feature-base"));
+    assert!(repo.is_ancestor("refs/heads/feature-base", "refs/heads/feature-child"));
+    assert_ne!(repo.local_sha("refs/heads/feature-base"), old_base_sha);
+    assert_ne!(repo.local_sha("refs/heads/feature-child"), old_child_sha);
+    assert_eq!(repo.remote_sha("feature-base"), old_base_sha);
+    assert_eq!(repo.remote_sha("feature-child"), old_child_sha);
+}


### PR DESCRIPTION
## Summary

Exercise core workflows against actual temporary Git repositories instead of relying exclusively on command stubs.

Adds an isolated test harness with a local bare `origin` and an offline GitHub CLI stub. Real-Git scenarios cover branch creation, submit/push, and rebasing a two-branch stack after `main` advances.

Adopts an N-2 Rust support policy with Rust 1.95 as the current minimum, uses Cargo resolver 3 for MSRV-aware dependency selection, and enforces locked stable, MSRV, and release builds. The existing dependency graph is preserved; `Cargo.lock` only corrects the `stck` package version to 0.1.4.

Stack position: 1 of 10. Base: `main`. No parent PR.

## Changelist

- `.github/workflows/ci.yml` — enforce locked builds and add Rust 1.95 validation
- `.github/workflows/release.yml` — enforce the release lockfile
- `Cargo.toml` — declare the N-2 MSRV and enable resolver 3
- `Cargo.lock` — align the package version with Cargo.toml
- `README.md` and `CONTRIBUTING.md` — document the support policy and matching validation commands
- `tests/harness/mod.rs` — add the isolated real-Git repository harness
- `tests/real_git.rs` — cover real branch creation, submit/push, and stack rebasing