### PR TITLE
Scope cached sync plans to their stack

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -6,7 +6,7 @@ use crate::env;
 use crate::github;
 use crate::gitops;
 use crate::stack;
-use crate::sync_state::{self, LastSyncPlan, PushState, SyncState};
+use crate::sync_state::{self, LastSyncPlan, PushState, SyncPlanScope, SyncState};
 
 /// Print the detected stack, its PR state, and any local follow-up actions.
 pub(crate) fn run_status(preflight: &env::PreflightContext) -> ExitCode {
@@ -490,6 +490,10 @@ pub(crate) fn run_sync(
                 force_rewrite_first_open,
             );
             if steps.is_empty() {
+                if let Err(message) = sync_state::clear_last_sync_plan() {
+                    eprintln!("error: {message}");
+                    return ExitCode::from(1);
+                }
                 println!("Stack is already up to date. No sync needed.");
                 return ExitCode::SUCCESS;
             }
@@ -499,6 +503,7 @@ pub(crate) fn run_sync(
                 completed_steps: 0,
                 failed_step: None,
                 failed_step_branch_head: None,
+                plan_scope: Some(SyncPlanScope::new(&preflight.repository, &stack)),
             };
             if let Err(message) = sync_state::save_sync(&state) {
                 eprintln!("error: {message}");
@@ -660,18 +665,24 @@ pub(crate) fn run_sync(
         return ExitCode::from(1);
     }
 
-    let last_plan = LastSyncPlan {
-        default_branch: preflight.default_branch.clone(),
-        retargets: state
-            .steps
-            .iter()
-            .map(|step| stack::RetargetStep {
-                branch: step.branch.clone(),
-                new_base_ref: step.new_base_ref.clone(),
-            })
-            .collect(),
-    };
-    if let Err(message) = sync_state::save_last_sync_plan(&last_plan) {
+    if let Some(scope) = state.plan_scope.clone() {
+        let last_plan = LastSyncPlan {
+            default_branch: preflight.default_branch.clone(),
+            scope: Some(scope),
+            retargets: state
+                .steps
+                .iter()
+                .map(|step| stack::RetargetStep {
+                    branch: step.branch.clone(),
+                    new_base_ref: step.new_base_ref.clone(),
+                })
+                .collect(),
+        };
+        if let Err(message) = sync_state::save_last_sync_plan(&last_plan) {
+            eprintln!("error: {message}");
+            return ExitCode::from(1);
+        }
+    } else if let Err(message) = sync_state::clear_last_sync_plan() {
         eprintln!("error: {message}");
         return ExitCode::from(1);
     }
@@ -750,9 +761,13 @@ pub(crate) fn run_push(preflight: &env::PreflightContext) -> ExitCode {
                 }
             };
             let retargets = if let Some(plan) = cached_plan {
-                if plan.default_branch == preflight.default_branch {
+                if plan.matches(&preflight.repository, &preflight.default_branch, &stack) {
                     plan.retargets
                 } else {
+                    if let Err(message) = sync_state::clear_last_sync_plan() {
+                        eprintln!("error: {message}");
+                        return ExitCode::from(1);
+                    }
                     stack::build_push_retargets(&stack, &preflight.default_branch)
                 }
             } else {

--- a/src/env.rs
+++ b/src/env.rs
@@ -5,6 +5,8 @@ use std::process::Command;
 /// Repository context gathered during preflight and reused by command handlers.
 #[derive(Debug, Clone)]
 pub struct PreflightContext {
+    /// The canonical GitHub repository name in `owner/name` form.
+    pub repository: String,
     /// The currently checked-out local branch.
     pub current_branch: String,
     /// The repository's default branch as reported by GitHub.
@@ -23,9 +25,10 @@ pub fn run_preflight() -> Result<PreflightContext, String> {
     ensure_origin_remote()?;
     let current_branch = ensure_on_branch()?;
     ensure_clean_working_tree()?;
-    let default_branch = discover_default_branch()?;
+    let (repository, default_branch) = discover_repository_context()?;
 
     Ok(PreflightContext {
+        repository,
         current_branch,
         default_branch,
     })
@@ -118,15 +121,15 @@ fn ensure_clean_working_tree() -> Result<(), String> {
     }
 }
 
-fn discover_default_branch() -> Result<String, String> {
+fn discover_repository_context() -> Result<(String, String), String> {
     let output = Command::new("gh")
         .args([
             "repo",
             "view",
             "--json",
-            "defaultBranchRef",
+            "nameWithOwner,defaultBranchRef",
             "--jq",
-            ".defaultBranchRef.name",
+            r#"[.nameWithOwner, .defaultBranchRef.name] | @tsv"#,
         ])
         .output()
         .map_err(|_| "failed to discover repository default branch from GitHub".to_string())?;
@@ -138,13 +141,24 @@ fn discover_default_branch() -> Result<String, String> {
         );
     }
 
-    let branch = String::from_utf8_lossy(&output.stdout).trim().to_string();
-    if branch.is_empty() {
+    let metadata = String::from_utf8_lossy(&output.stdout);
+    let Some((repository, default_branch)) = metadata.trim().split_once('\t') else {
+        return Err(
+            "repository metadata lookup returned an invalid result; verify repository metadata on GitHub"
+                .to_string(),
+        );
+    };
+    if default_branch.is_empty() {
         Err(
             "default branch lookup returned empty result; verify repository metadata on GitHub"
                 .to_string(),
         )
+    } else if repository.is_empty() {
+        Err(
+            "repository identity lookup returned empty result; verify repository metadata on GitHub"
+                .to_string(),
+        )
     } else {
-        Ok(branch)
+        Ok((repository.to_string(), default_branch.to_string()))
     }
 }

--- a/src/github.rs
+++ b/src/github.rs
@@ -1,12 +1,12 @@
 //! GitHub pull request discovery and mutation helpers backed by the `gh` CLI.
 
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use std::process::Command;
 
 use crate::util::with_stderr;
 
 /// The GitHub state of a pull request as returned by `gh`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum PrState {
     /// The pull request is still open.
@@ -28,7 +28,7 @@ impl std::fmt::Display for PrState {
 }
 
 /// Minimal pull request metadata needed to reason about a linear stack.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
 pub struct PullRequest {
     /// The GitHub pull request number.
     pub number: u64,

--- a/src/sync_state.rs
+++ b/src/sync_state.rs
@@ -1,5 +1,6 @@
 //! Persistence for resumable `sync` and `push` workflows under `.git/stck/`.
 
+use crate::github::PullRequest;
 use crate::gitops;
 use crate::stack::{RetargetStep, SyncStep};
 use serde::{Deserialize, Serialize};
@@ -18,6 +19,9 @@ pub struct SyncState {
     /// Recorded branch head after the failed step began, used to validate resume behavior.
     #[serde(default)]
     pub failed_step_branch_head: Option<String>,
+    /// Repository and PR stack the sync plan was computed for.
+    #[serde(default)]
+    pub(crate) plan_scope: Option<SyncPlanScope>,
 }
 
 /// Saved progress for an in-flight `stck push` operation.
@@ -38,8 +42,49 @@ pub struct PushState {
 pub struct LastSyncPlan {
     /// The default branch that the cached plan was built against.
     pub default_branch: String,
+    /// Repository and exact PR stack that produced the cached plan.
+    #[serde(default)]
+    pub(crate) scope: Option<SyncPlanScope>,
     /// PR retarget operations implied by the sync plan.
     pub retargets: Vec<RetargetStep>,
+}
+
+/// Identity required before a cached sync plan can be reused by `stck push`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct SyncPlanScope {
+    repository: String,
+    stack: Vec<PullRequest>,
+}
+
+impl SyncPlanScope {
+    /// Capture the repository and exact ordered PR metadata for a sync plan.
+    pub(crate) fn new(repository: &str, stack: &[PullRequest]) -> Self {
+        Self {
+            repository: repository.to_string(),
+            stack: stack.to_vec(),
+        }
+    }
+
+    /// Return whether this scope still describes the current repository stack.
+    pub(crate) fn matches(&self, repository: &str, stack: &[PullRequest]) -> bool {
+        self.repository == repository && self.stack == stack
+    }
+}
+
+impl LastSyncPlan {
+    /// Return whether this cached plan is safe to reuse for the current stack.
+    pub(crate) fn matches(
+        &self,
+        repository: &str,
+        default_branch: &str,
+        stack: &[PullRequest],
+    ) -> bool {
+        self.default_branch == default_branch
+            && self
+                .scope
+                .as_ref()
+                .is_some_and(|scope| scope.matches(repository, stack))
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -178,7 +223,29 @@ fn save_raw_state(state: LastPlanState) -> Result<(), String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::github::PrState;
     use crate::stack::{RetargetStep, SyncStep};
+
+    fn stack() -> Vec<PullRequest> {
+        vec![
+            PullRequest {
+                number: 101,
+                head_ref_name: "feature-b".to_string(),
+                base_ref_name: "main".to_string(),
+                state: PrState::Open,
+            },
+            PullRequest {
+                number: 102,
+                head_ref_name: "feature-c".to_string(),
+                base_ref_name: "feature-b".to_string(),
+                state: PrState::Open,
+            },
+        ]
+    }
+
+    fn scope() -> SyncPlanScope {
+        SyncPlanScope::new("example/stck", &stack())
+    }
 
     #[test]
     fn sync_state_round_trip() {
@@ -198,6 +265,7 @@ mod tests {
             completed_steps: 1,
             failed_step: Some(1),
             failed_step_branch_head: Some("abcd1234".to_string()),
+            plan_scope: Some(scope()),
         };
 
         let wrapped = LastPlanState::Sync(state.clone());
@@ -213,6 +281,7 @@ mod tests {
                 assert_eq!(s.completed_steps, 1);
                 assert_eq!(s.failed_step, Some(1));
                 assert_eq!(s.failed_step_branch_head, Some("abcd1234".to_string()));
+                assert_eq!(s.plan_scope, Some(scope()));
             }
             LastPlanState::Push(_) => panic!("expected Sync variant"),
         }
@@ -251,6 +320,7 @@ mod tests {
     fn last_sync_plan_round_trip() {
         let plan = LastSyncPlan {
             default_branch: "main".to_string(),
+            scope: Some(scope()),
             retargets: vec![
                 RetargetStep {
                     branch: "feature-b".to_string(),
@@ -268,6 +338,7 @@ mod tests {
             serde_json::from_slice(&json).expect("deserialize should succeed");
 
         assert_eq!(restored.default_branch, "main");
+        assert_eq!(restored.scope, Some(scope()));
         assert_eq!(restored.retargets.len(), 2);
         assert_eq!(restored.retargets[0].branch, "feature-b");
         assert_eq!(restored.retargets[1].new_base_ref, "feature-b");
@@ -280,6 +351,7 @@ mod tests {
             completed_steps: 0,
             failed_step: None,
             failed_step_branch_head: None,
+            plan_scope: Some(scope()),
         });
         let push = LastPlanState::Push(PushState {
             push_branches: vec![],
@@ -316,6 +388,7 @@ mod tests {
             completed_steps: 1,
             failed_step: None,
             failed_step_branch_head: None,
+            plan_scope: Some(scope()),
         };
 
         let wrapped = LastPlanState::Sync(state);
@@ -331,5 +404,38 @@ mod tests {
             }
             LastPlanState::Push(_) => panic!("expected Sync variant"),
         }
+    }
+
+    #[test]
+    fn last_sync_plan_matches_only_the_exact_repository_stack() {
+        let plan = LastSyncPlan {
+            default_branch: "main".to_string(),
+            scope: Some(scope()),
+            retargets: vec![],
+        };
+
+        assert!(plan.matches("example/stck", "main", &stack()));
+        assert!(!plan.matches("other/stck", "main", &stack()));
+        assert!(!plan.matches("example/stck", "trunk", &stack()));
+
+        let mut changed_stack = stack();
+        changed_stack[1].number = 999;
+        assert!(!plan.matches("example/stck", "main", &changed_stack));
+    }
+
+    #[test]
+    fn legacy_unscoped_last_sync_plan_is_not_reusable() {
+        let raw = r#"{
+  "default_branch": "main",
+  "retargets": [
+    {"branch": "feature-b", "new_base_ref": "main"}
+  ]
+}"#;
+
+        let plan: LastSyncPlan =
+            serde_json::from_str(raw).expect("legacy cached plan should remain readable");
+
+        assert_eq!(plan.scope, None);
+        assert!(!plan.matches("example/stck", "main", &stack()));
     }
 }

--- a/tests/harness/mod.rs
+++ b/tests/harness/mod.rs
@@ -394,7 +394,7 @@ if [[ "${1:-}" == "repo" && "${2:-}" == "view" ]]; then
   if [[ "${STCK_TEST_DEFAULT_BRANCH_FAIL:-0}" == "1" ]]; then
     exit 1
   fi
-  echo "main"
+  printf 'example/stck\tmain\n'
   exit 0
 fi
 
@@ -625,7 +625,7 @@ if [[ "${1:-}" == "auth" && "${2:-}" == "status" ]]; then
 fi
 
 if [[ "${1:-}" == "repo" && "${2:-}" == "view" ]]; then
-  echo "main"
+  printf 'example/stck\tmain\n'
   exit 0
 fi
 

--- a/tests/push.rs
+++ b/tests/push.rs
@@ -153,7 +153,7 @@ fn push_resumes_after_partial_retarget_failure() {
 }
 
 #[test]
-fn push_uses_cached_sync_plan_retargets_when_available() {
+fn push_uses_scoped_cached_sync_plan_when_stack_matches() {
     let (temp, mut sync) = stck_cmd_with_stubbed_tools();
     let log_path = log_path(&temp, "push-cached-plan.log");
 
@@ -181,7 +181,6 @@ fn push_uses_cached_sync_plan_retargets_when_available() {
         "STCK_TEST_NEEDS_PUSH_BRANCHES",
         "feature-branch,feature-child",
     );
-    push.env("STCK_TEST_SYNC_NOOP", "1");
     push.arg("push");
 
     push.assert()
@@ -201,7 +200,7 @@ fn push_uses_cached_sync_plan_retargets_when_available() {
 }
 
 #[test]
-fn push_skips_cached_sync_plan_retargets_that_are_already_satisfied() {
+fn push_discards_cached_sync_plan_when_stack_metadata_changes() {
     let (temp, mut sync) = stck_cmd_with_stubbed_tools();
     let log_path = log_path(&temp, "push-cached-plan-noop-retargets.log");
 
@@ -242,7 +241,7 @@ fn push_skips_cached_sync_plan_retargets_that_are_already_satisfied() {
     let log = fs::read_to_string(&log_path).expect("push log should exist");
     assert!(
         !log.contains("pr edit"),
-        "push should skip retarget calls when cached plan bases are already satisfied"
+        "push should recompute retargets instead of reusing a cached plan for changed PR metadata"
     );
     assert!(
         !cached_plan_path.exists(),

--- a/tests/real_git.rs
+++ b/tests/real_git.rs
@@ -114,3 +114,71 @@ fn sync_rebases_a_real_linear_stack_after_main_advances() {
     assert_eq!(repo.remote_sha("feature-base"), old_base_sha);
     assert_eq!(repo.remote_sha("feature-child"), old_child_sha);
 }
+
+#[test]
+fn push_does_not_reuse_a_real_cached_plan_for_another_stack() {
+    let repo = RealGitRepo::new();
+
+    repo.create_branch("stack-a-base");
+    repo.commit_file("stack-a-base.txt", "base a\n", "Add stack A base");
+    repo.push("stack-a-base");
+    repo.create_branch("stack-a-child");
+    repo.commit_file("stack-a-child.txt", "child a\n", "Add stack A child");
+    repo.push("stack-a-child");
+
+    repo.checkout("main");
+    repo.commit_file("main-ahead.txt", "main ahead\n", "Advance main");
+    repo.push("main");
+    repo.checkout("stack-a-base");
+
+    repo.write_pr_response(
+        "stack-a-base",
+        r#"{"number":201,"headRefName":"stack-a-base","baseRefName":"main","state":"OPEN"}"#,
+    );
+    repo.write_pr_response(
+        "stack-a-child",
+        r#"{"number":202,"headRefName":"stack-a-child","baseRefName":"stack-a-base","state":"OPEN"}"#,
+    );
+    repo.write_children_response(
+        "stack-a-base",
+        r#"[{"number":202,"headRefName":"stack-a-child","baseRefName":"stack-a-base","state":"OPEN"}]"#,
+    );
+    repo.write_children_response("stack-a-child", "[]");
+
+    let mut sync = repo.stck_cmd();
+    sync.arg("sync");
+    sync.assert().success();
+
+    repo.checkout("main");
+    repo.create_branch("stack-b-base");
+    repo.commit_file("stack-b-base.txt", "base b\n", "Add stack B base");
+    repo.push("stack-b-base");
+    repo.create_branch("stack-b-child");
+    repo.commit_file("stack-b-child.txt", "child b\n", "Add stack B child");
+    repo.push("stack-b-child");
+
+    repo.write_pr_response(
+        "stack-b-base",
+        r#"{"number":301,"headRefName":"stack-b-base","baseRefName":"main","state":"OPEN"}"#,
+    );
+    repo.write_pr_response(
+        "stack-b-child",
+        r#"{"number":302,"headRefName":"stack-b-child","baseRefName":"stack-b-base","state":"OPEN"}"#,
+    );
+    repo.write_children_response("stack-b-child", "[]");
+
+    let mut push = repo.stck_cmd();
+    push.arg("push");
+    push.assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "Push succeeded. Pushed 0 branch(es) and applied 0 PR base update(s) in this run.",
+        ))
+        .stdout(predicate::str::contains("$ gh pr edit").not());
+
+    let gh_log = repo.gh_log();
+    assert!(
+        !gh_log.contains("pr edit stack-a-base") && !gh_log.contains("pr edit stack-a-child"),
+        "push for stack B must not apply stack A's cached retarget plan"
+    );
+}

--- a/tests/sync.rs
+++ b/tests/sync.rs
@@ -95,6 +95,35 @@ fn sync_reports_noop_when_stack_is_already_up_to_date() {
 }
 
 #[test]
+fn sync_noop_clears_a_stale_cached_plan() {
+    let (temp, mut cmd) = stck_cmd_with_stubbed_tools();
+    let stck_dir = temp.path().join("git-dir").join("stck");
+    fs::create_dir_all(&stck_dir).expect("stck state dir should be created");
+    let cached_plan_path = stck_dir.join("last-sync-plan.json");
+    fs::write(
+        &cached_plan_path,
+        r#"{
+  "default_branch": "main",
+  "retargets": [
+    {"branch": "other-feature", "new_base_ref": "main"}
+  ]
+}"#,
+    )
+    .expect("stale cached plan should be written");
+
+    cmd.env("STCK_TEST_SYNC_NOOP", "1");
+    cmd.arg("sync");
+
+    cmd.assert().success().stdout(predicate::str::contains(
+        "Stack is already up to date. No sync needed.",
+    ));
+    assert!(
+        !cached_plan_path.exists(),
+        "a no-op sync should clear the previous stack's cached plan"
+    );
+}
+
+#[test]
 fn sync_from_mid_stack_rebases_current_and_descendants() {
     let (temp, mut cmd) = stck_cmd_with_stubbed_tools();
     let log_path = log_path(&temp, "stck-sync-mid-stack.log");


### PR DESCRIPTION
## Summary

Prevent a cached sync retarget plan from being reused for a different repository or PR stack.

Cached plans now record the canonical GitHub repository plus the exact ordered PR metadata—including numbers, branches, bases, and states. `push` only reuses a plan when that complete identity still matches; otherwise it clears the cache and recomputes safely.

Legacy unscoped caches remain readable but cannot be reused, and a no-op sync removes any stale cached plan. A real-Git regression test covers syncing stack A, switching to stack B, and verifying that no stack A PRs are edited.

Stack position: 2 of 10. Base: `main`. Parent PR: #50 (merged).

## Changelist

- `src/env.rs` and `src/github.rs` — provide canonical repository and serializable PR identity
- `src/sync_state.rs` — persist and validate repository/stack scope with backward-compatible deserialization
- `src/commands.rs` — reuse only exact-matching plans and clear stale or mismatched caches
- `tests/real_git.rs` — prove one stack cannot apply another stack’s cached retargets
- `tests/sync.rs` and `tests/push.rs` — cover no-op cleanup, matching scopes, metadata changes, and legacy caches
- `tests/harness/mod.rs` — provide canonical repository metadata to offline tests