### PR TITLE
Detect parent drift during discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ stck push
 
 `stck new <branch>` works both when starting from the default branch and when stacking on top of an existing branch.
 
-`stck submit` auto-detects the most likely stack parent when `--base` is omitted. If discovery succeeds but finds no parent PR, it falls back to the repository default branch. In larger repositories, discovery currently inspects up to the first 100 open PRs, so `--base <branch>` remains the reliable escape hatch.
+`stck submit` auto-detects the most likely stack parent when `--base` is omitted. If discovery can inspect every candidate but finds no parent PR, it falls back to the repository default branch. Missing refs or failed ancestry checks stop discovery instead of silently selecting the default branch. In larger repositories, discovery currently inspects up to the first 100 open PRs, so `--base <branch>` remains the reliable escape hatch.
 
 Git subcommand entrypoint is also installed (when installed via homebrew):
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -73,8 +73,8 @@ stck submit --base feature-a
 `submit` creates a PR for the current branch when one does not exist.
 
 - If no `--base` is provided, `stck` first tries to auto-detect the stack parent from open PR metadata.
-- If discovery succeeds but finds no parent PR, `stck` falls back to the repository default branch.
-- If GitHub lookup fails, `stck` errors and tells you to retry or pass `--base <branch>` explicitly.
+- If discovery checks every available candidate and finds no parent PR, `stck` falls back to the repository default branch.
+- If GitHub lookup, ref resolution, or an ancestry check fails, `stck` errors and tells you to retry or pass `--base <branch>` explicitly.
 - Parent auto-discovery currently inspects up to the first 100 open PRs, so `--base` is the reliable override in larger repositories.
 - Use `--base` any time you want to target a stack parent branch explicitly.
 - If the current branch already has a PR, it reports a no-op.

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -200,14 +200,13 @@ pub(crate) fn run_new(preflight: &env::PreflightContext, new_branch: &str) -> Ex
         };
 
         if !current_has_pr {
-            let bootstrap_base =
-                match discover_parent_base(current_branch, &preflight.default_branch) {
-                    Ok(base) => base,
-                    Err(message) => {
-                        eprintln!("error: {message}");
-                        return ExitCode::from(1);
-                    }
-                };
+            let bootstrap_base = match discover_parent_base(current_branch) {
+                Ok(base) => base.unwrap_or_else(|| preflight.default_branch.clone()),
+                Err(message) => {
+                    eprintln!("error: {message}");
+                    return ExitCode::from(1);
+                }
+            };
             println!(
                 "$ gh pr create --base {} --head {} --title {} --body \"\"",
                 bootstrap_base, current_branch, current_branch
@@ -263,38 +262,49 @@ pub(crate) fn run_new(preflight: &env::PreflightContext, new_branch: &str) -> Ex
     ExitCode::SUCCESS
 }
 
-/// Discover the intended PR base for a branch by looking for its parent in the open stack.
-fn discover_parent_base(branch: &str, default_branch: &str) -> Result<String, String> {
-    let prs = github::list_open_prs().map_err(|message| {
-        format!(
-            "could not auto-detect stack parent for {branch}: {message}; retry or pass `--base <branch>` explicitly"
-        )
-    })?;
+fn parent_discovery_error(branch: &str, message: &str) -> String {
+    format!(
+        "could not auto-detect stack parent for {branch}: {message}; retry or pass `--base <branch>` explicitly"
+    )
+}
+
+/// Discover the intended PR parent from open PR metadata and Git ancestry.
+///
+/// `Ok(None)` means discovery completed and no parent is an ancestor. Any
+/// GitHub, ref-resolution, or ancestry-check failure is returned separately so
+/// callers cannot silently create a PR against the default branch.
+fn discover_parent_base(branch: &str) -> Result<Option<String>, String> {
+    let candidate_branches = github::list_open_pr_head_branches()
+        .map_err(|message| parent_discovery_error(branch, &message))?;
+    gitops::fetch_origin().map_err(|message| parent_discovery_error(branch, &message))?;
 
     let branch_ref = format!("refs/heads/{branch}");
-    let mut best: Option<&str> = None;
+    let mut best: Option<(String, String)> = None;
 
-    for pr in &prs {
-        if pr.head_ref_name == branch || pr.head_ref_name == default_branch {
+    for candidate in candidate_branches {
+        if candidate == branch {
             continue;
         }
-        if pr.state != github::PrState::Open {
-            continue;
-        }
-        let candidate_ref = format!("refs/heads/{}", pr.head_ref_name);
-        if gitops::is_ancestor(&candidate_ref, &branch_ref).unwrap_or(false) {
-            if let Some(current_best) = best {
-                let current_best_ref = format!("refs/heads/{current_best}");
-                if gitops::is_ancestor(&current_best_ref, &candidate_ref).unwrap_or(false) {
-                    best = Some(&pr.head_ref_name);
+
+        let candidate_ref = gitops::resolve_branch_ref_remote_first(&candidate)
+            .map_err(|message| parent_discovery_error(branch, &message))?;
+        let is_ancestor = gitops::is_ancestor(&candidate_ref, &branch_ref)
+            .map_err(|message| parent_discovery_error(branch, &message))?;
+
+        if is_ancestor {
+            if let Some((_, current_best_ref)) = &best {
+                let is_closer_parent = gitops::is_ancestor(current_best_ref, &candidate_ref)
+                    .map_err(|message| parent_discovery_error(branch, &message))?;
+                if is_closer_parent {
+                    best = Some((candidate, candidate_ref));
                 }
             } else {
-                best = Some(&pr.head_ref_name);
+                best = Some((candidate, candidate_ref));
             }
         }
     }
 
-    Ok(best.unwrap_or(default_branch).to_string())
+    Ok(best.map(|(branch, _)| branch))
 }
 
 /// Create a pull request for the current branch if one does not already exist.
@@ -357,8 +367,8 @@ pub(crate) fn run_submit(
     let base = if let Some(explicit) = base_override {
         explicit
     } else {
-        discovered_base = match discover_parent_base(current_branch, &preflight.default_branch) {
-            Ok(base) => base,
+        discovered_base = match discover_parent_base(current_branch) {
+            Ok(base) => base.unwrap_or_else(|| preflight.default_branch.clone()),
             Err(message) => {
                 eprintln!("error: {message}");
                 return ExitCode::from(1);

--- a/src/github.rs
+++ b/src/github.rs
@@ -42,6 +42,14 @@ pub struct PullRequest {
     pub state: PrState,
 }
 
+#[derive(Debug, Deserialize)]
+struct OpenPullRequestHead {
+    #[serde(rename = "headRefName")]
+    head_ref_name: String,
+    #[serde(rename = "isCrossRepository", default)]
+    is_cross_repository: bool,
+}
+
 /// Discover the full linear stack surrounding `current_branch`.
 ///
 /// The returned list is ordered from the stack root to the highest descendant
@@ -185,12 +193,13 @@ pub fn create_pr(base: &str, head: &str, title: &str) -> Result<(), String> {
     }
 }
 
-/// List open pull requests visible to the current repository.
+/// List same-repository head branches for open pull requests.
 ///
 /// This currently relies on `gh pr list --limit 100`, so callers should treat
 /// it as a best-effort discovery source rather than a complete repository-wide
-/// index in very large repositories.
-pub fn list_open_prs() -> Result<Vec<PullRequest>, String> {
+/// index in very large repositories. Cross-repository pull requests are
+/// excluded because their head branches are not available through `origin`.
+pub fn list_open_pr_head_branches() -> Result<Vec<String>, String> {
     let output = Command::new("gh")
         .args([
             "pr",
@@ -200,7 +209,7 @@ pub fn list_open_prs() -> Result<Vec<PullRequest>, String> {
             "--limit",
             "100",
             "--json",
-            "number,headRefName,baseRefName,state",
+            "headRefName,isCrossRepository",
         ])
         .output()
         .map_err(|_| "failed to run `gh pr list`; ensure GitHub CLI is installed".to_string())?;
@@ -212,7 +221,13 @@ pub fn list_open_prs() -> Result<Vec<PullRequest>, String> {
         ));
     }
 
-    parse_pull_requests_json(&output.stdout)
+    let prs = serde_json::from_slice::<Vec<OpenPullRequestHead>>(&output.stdout)
+        .map_err(|_| "failed to parse PR metadata from GitHub CLI output".to_string())?;
+    Ok(prs
+        .into_iter()
+        .filter(|pr| !pr.is_cross_repository)
+        .map(|pr| pr.head_ref_name)
+        .collect())
 }
 
 fn fetch_pr_for_branch(branch: &str) -> Result<PullRequest, String> {

--- a/src/gitops.rs
+++ b/src/gitops.rs
@@ -52,6 +52,26 @@ pub fn resolve_onto_ref(base_branch: &str) -> Result<String, String> {
     resolve_base_ref(base_branch)
 }
 
+/// Resolve a branch through its fetched `origin` ref, then its local ref.
+///
+/// Parent discovery uses this to avoid stale or missing local branches while
+/// retaining a fallback for clones without the corresponding tracking ref.
+pub fn resolve_branch_ref_remote_first(branch: &str) -> Result<String, String> {
+    let remote_ref = format!("refs/remotes/origin/{branch}");
+    if ref_exists(&remote_ref)? {
+        return Ok(remote_ref);
+    }
+
+    let local_ref = format!("refs/heads/{branch}");
+    if ref_exists(&local_ref)? {
+        return Ok(local_ref);
+    }
+
+    Err(format!(
+        "could not resolve branch `{branch}` from `origin` or local refs"
+    ))
+}
+
 /// Resolve the fork point to use as the old base for `git rebase --onto`.
 ///
 /// This prefers the merge-base between `branch` and `base_branch` so sync can

--- a/tests/harness/mod.rs
+++ b/tests/harness/mod.rs
@@ -246,6 +246,15 @@ fi
 if [[ "${1:-}" == "merge-base" && "${2:-}" == "--is-ancestor" ]]; then
   ancestor="${3:-}"
   descendant="${4:-}"
+  if [[ "${STCK_TEST_STALE_LOCAL_PARENT:-}" != "" && "${ancestor}" == "refs/heads/${STCK_TEST_STALE_LOCAL_PARENT}" ]]; then
+    exit 1
+  fi
+  if [[ "${STCK_TEST_MISSING_LOCAL_BRANCH_REF:-}" != "" && ( "${ancestor}" == "refs/heads/${STCK_TEST_MISSING_LOCAL_BRANCH_REF}" || "${descendant}" == "refs/heads/${STCK_TEST_MISSING_LOCAL_BRANCH_REF}" ) ]]; then
+    exit 128
+  fi
+  if [[ "${STCK_TEST_MISSING_REMOTE_BRANCH:-}" != "" && ( "${ancestor}" == "refs/remotes/origin/${STCK_TEST_MISSING_REMOTE_BRANCH}" || "${descendant}" == "refs/remotes/origin/${STCK_TEST_MISSING_REMOTE_BRANCH}" ) ]]; then
+    exit 128
+  fi
   if [[ "${STCK_TEST_DEFAULT_ADVANCED:-0}" == "1" && "${ancestor}" == "refs/remotes/origin/main" && "${descendant}" == "refs/heads/feature-base" ]]; then
     exit 1
   fi
@@ -253,6 +262,10 @@ if [[ "${1:-}" == "merge-base" && "${2:-}" == "--is-ancestor" ]]; then
   ancestor_branch="${ancestor_branch#refs/remotes/origin/}"
   descendant_branch="${descendant#refs/heads/}"
   descendant_branch="${descendant_branch#refs/remotes/origin/}"
+
+  if [[ ",${STCK_TEST_ANCESTRY_ERROR_PAIRS:-}," == *",${ancestor_branch}:${descendant_branch},"* ]]; then
+    exit 128
+  fi
 
   if [[ -n "${STCK_TEST_NOT_ANCESTOR_PAIRS:-}" ]]; then
     IFS=',' read -ra pairs <<< "${STCK_TEST_NOT_ANCESTOR_PAIRS}"
@@ -752,6 +765,10 @@ exit 1
         self.git_success(&["checkout", branch]);
     }
 
+    pub fn delete_local_branch(&self, branch: &str) {
+        self.git_success(&["branch", "-d", branch]);
+    }
+
     pub fn commit_file(&self, relative_path: &str, contents: &str, message: &str) {
         let path = self.worktree.join(relative_path);
         if let Some(parent) = path.parent() {
@@ -818,6 +835,11 @@ exit 1
             json,
         )
         .expect("gh children response should be written");
+    }
+
+    pub fn write_open_prs_response(&self, json: &str) {
+        fs::write(self.gh_responses.join("pr-list-open.json"), json)
+            .expect("gh open PR response should be written");
     }
 
     pub fn gh_log(&self) -> String {

--- a/tests/new.rs
+++ b/tests/new.rs
@@ -115,6 +115,30 @@ fn new_from_stacked_branch_discovers_parent_base() {
 }
 
 #[test]
+fn new_prefers_remote_parent_when_local_parent_has_drifted() {
+    let (temp, mut cmd) = stck_cmd_with_stubbed_tools();
+    let log_path = log_path(&temp, "stck-new-remote-parent.log");
+    cmd.env("STCK_TEST_LOG", log_path.as_os_str());
+    cmd.env("STCK_TEST_NEW_BRANCH_HAS_COMMITS", "1");
+    cmd.env("STCK_TEST_STALE_LOCAL_PARENT", "feature-base");
+    cmd.env(
+        "STCK_TEST_OPEN_PRS_JSON",
+        r#"[{"headRefName":"feature-base","isCrossRepository":false}]"#,
+    );
+    cmd.args(["new", "feature-next"]);
+
+    cmd.assert().success().stdout(predicate::str::contains(
+        "$ gh pr create --base feature-base --head feature-branch",
+    ));
+
+    let log = fs::read_to_string(&log_path).expect("new log should exist");
+    assert!(
+        log.contains("pr create --base feature-base --head feature-branch"),
+        "bootstrap PR should use the remote parent when its local ref has drifted"
+    );
+}
+
+#[test]
 fn new_fails_when_parent_discovery_errors() {
     let (_temp, mut cmd) = stck_cmd_with_stubbed_tools();
     cmd.env("STCK_TEST_PR_LIST_FAIL", "1");

--- a/tests/real_git.rs
+++ b/tests/real_git.rs
@@ -59,6 +59,35 @@ fn submit_pushes_a_real_branch_before_creating_its_pr() {
 }
 
 #[test]
+fn submit_discovers_a_remote_parent_without_its_local_branch() {
+    let repo = RealGitRepo::new();
+    repo.create_branch("feature-base");
+    repo.commit_file("base.txt", "base\n", "Add base feature");
+    repo.push("feature-base");
+
+    repo.create_branch("feature-child");
+    repo.commit_file("child.txt", "child\n", "Add child feature");
+    repo.delete_local_branch("feature-base");
+    repo.write_open_prs_response(r#"[{"headRefName":"feature-base","isCrossRepository":false}]"#);
+
+    let mut cmd = repo.stck_cmd();
+    cmd.arg("submit");
+
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "No --base provided. Detected stack parent: feature-base.",
+        ))
+        .stdout(predicate::str::contains(
+            "$ gh pr create --base feature-base --head feature-child",
+        ));
+
+    let gh_log = repo.gh_log();
+    assert!(gh_log.contains("pr list --state open --limit 100"));
+    assert!(gh_log.contains("pr create --base feature-base --head feature-child"));
+}
+
+#[test]
 fn sync_rebases_a_real_linear_stack_after_main_advances() {
     let repo = RealGitRepo::new();
 

--- a/tests/submit.rs
+++ b/tests/submit.rs
@@ -69,6 +69,75 @@ fn submit_fails_when_parent_discovery_errors() {
 }
 
 #[test]
+fn submit_fails_when_parent_candidate_refs_are_missing() {
+    let (temp, mut cmd) = stck_cmd_with_stubbed_tools();
+    let log_path = log_path(&temp, "stck-submit-missing-parent-refs.log");
+    cmd.env("STCK_TEST_LOG", log_path.as_os_str());
+    cmd.env("STCK_TEST_MISSING_LOCAL_BRANCH_REF", "feature-base");
+    cmd.env("STCK_TEST_MISSING_REMOTE_BRANCH", "feature-base");
+    cmd.env(
+        "STCK_TEST_OPEN_PRS_JSON",
+        r#"[{"headRefName":"feature-base","isCrossRepository":false}]"#,
+    );
+    cmd.arg("submit");
+
+    cmd.assert().code(1).stderr(predicate::str::contains(
+        "error: could not auto-detect stack parent for feature-branch: could not resolve branch `feature-base` from `origin` or local refs; retry or pass `--base <branch>` explicitly",
+    ));
+
+    let log = fs::read_to_string(&log_path).expect("submit log should exist");
+    assert!(
+        !log.contains("pr create"),
+        "submit must not fall back to main when a parent candidate cannot be resolved"
+    );
+}
+
+#[test]
+fn submit_fails_when_parent_ancestry_check_errors() {
+    let (temp, mut cmd) = stck_cmd_with_stubbed_tools();
+    let log_path = log_path(&temp, "stck-submit-ancestry-error.log");
+    cmd.env("STCK_TEST_LOG", log_path.as_os_str());
+    cmd.env(
+        "STCK_TEST_ANCESTRY_ERROR_PAIRS",
+        "feature-base:feature-branch",
+    );
+    cmd.env(
+        "STCK_TEST_OPEN_PRS_JSON",
+        r#"[{"headRefName":"feature-base","isCrossRepository":false}]"#,
+    );
+    cmd.arg("submit");
+
+    cmd.assert().code(1).stderr(predicate::str::contains(
+        "error: could not auto-detect stack parent for feature-branch: failed to check ancestry between `refs/remotes/origin/feature-base` and `refs/heads/feature-branch`; retry or pass `--base <branch>` explicitly",
+    ));
+
+    let log = fs::read_to_string(&log_path).expect("submit log should exist");
+    assert!(
+        !log.contains("pr create"),
+        "submit must not fall back to main when ancestry cannot be verified"
+    );
+}
+
+#[test]
+fn submit_ignores_cross_repository_parent_candidates() {
+    let (_temp, mut cmd) = stck_cmd_with_stubbed_tools();
+    cmd.env(
+        "STCK_TEST_OPEN_PRS_JSON",
+        r#"[{"headRefName":"fork-feature","isCrossRepository":true}]"#,
+    );
+    cmd.arg("submit");
+
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "No --base provided. Defaulting PR base to main.",
+        ))
+        .stdout(predicate::str::contains(
+            "$ gh pr create --base main --head feature-branch",
+        ));
+}
+
+#[test]
 fn submit_explicit_base_overrides_parent_discovery() {
     let (temp, mut cmd) = stck_cmd_with_stubbed_tools();
     let log_path = log_path(&temp, "stck-submit-explicit-override.log");


### PR DESCRIPTION
## Summary

Prevent parent auto-discovery from silently selecting the default branch when local candidate refs have drifted or Git cannot verify ancestry.

Discovery now refreshes `origin`, prefers remote refs, ignores cross-repository heads, and distinguishes a proven “no parent” result from ref or ancestry failures. This keeps both `new` and `submit` fail-closed while preserving explicit `--base` overrides.

Stack position: 3 of 10. Base: `scope-sync-state`. Parent PR: #51.

## Changelist

- `src/commands.rs` — distinguish no-parent results from discovery failures and select the nearest verified ancestor
- `src/gitops.rs` — resolve parent branches through fetched origin refs before local fallbacks
- `src/github.rs` — exclude cross-repository PR heads from local parent discovery
- `tests/` — cover drifted and missing refs, ancestry errors, fork candidates, and the real-Git missing-local-parent scenario
- `README.md` and `USAGE.md` — document fail-closed ancestry behavior