### PR TITLE
Push missing remote branches

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -112,6 +112,7 @@ stck push
 `push` applies remote changes for the last computed stack state:
 
 - pushes stack branches with `--force-with-lease`,
+- creates a missing remote branch while keeping the ancestry guard for existing remote branches,
 - applies pending PR base retarget operations,
 - reports summary and remaining work on failure.
 

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -820,22 +820,31 @@ pub(crate) fn run_push(preflight: &env::PreflightContext) -> ExitCode {
 
         let remote_ref = format!("refs/remotes/origin/{branch}");
         let local_ref = format!("refs/heads/{branch}");
-        match gitops::is_ancestor(&remote_ref, &local_ref) {
-            Ok(true) => {}
-            Ok(false) => {
-                if let Err(save_error) = sync_state::save_push(&state) {
-                    eprintln!("error: {save_error}");
-                    return ExitCode::from(1);
-                }
-                eprintln!(
-                    "error: remote branch `origin/{branch}` has commits not in local `{branch}`; \
-                     pull or rebase to integrate remote changes before pushing"
-                );
-                return ExitCode::from(1);
-            }
+        let remote_exists = match gitops::remote_branch_exists(branch) {
+            Ok(exists) => exists,
             Err(message) => {
                 eprintln!("error: {message}");
                 return ExitCode::from(1);
+            }
+        };
+        if remote_exists {
+            match gitops::is_ancestor(&remote_ref, &local_ref) {
+                Ok(true) => {}
+                Ok(false) => {
+                    if let Err(save_error) = sync_state::save_push(&state) {
+                        eprintln!("error: {save_error}");
+                        return ExitCode::from(1);
+                    }
+                    eprintln!(
+                        "error: remote branch `origin/{branch}` has commits not in local `{branch}`; \
+                         pull or rebase to integrate remote changes before pushing"
+                    );
+                    return ExitCode::from(1);
+                }
+                Err(message) => {
+                    eprintln!("error: {message}");
+                    return ExitCode::from(1);
+                }
             }
         }
 

--- a/tests/harness/mod.rs
+++ b/tests/harness/mod.rs
@@ -156,6 +156,9 @@ fi
 
 if [[ "${1:-}" == "show-ref" && "${2:-}" == "--verify" && "${3:-}" == "--quiet" ]]; then
   ref="${4:-}"
+  if [[ "${STCK_TEST_REF_LOOKUP_FAIL:-}" == "${ref}" ]]; then
+    exit 128
+  fi
   if [[ "${ref}" == refs/heads/* ]]; then
     branch="${ref#refs/heads/}"
     if [[ "${STCK_TEST_LOCAL_BRANCH_EXISTS:-}" == "${branch}" ]]; then

--- a/tests/push.rs
+++ b/tests/push.rs
@@ -332,6 +332,55 @@ fn push_skips_branches_without_local_changes() {
 }
 
 #[test]
+fn push_publishes_a_branch_when_its_remote_ref_is_missing() {
+    let (temp, mut cmd) = stck_cmd_with_stubbed_tools();
+    let log_path = log_path(&temp, "stck-push-missing-remote.log");
+    cmd.env("STCK_TEST_LOG", log_path.as_os_str());
+    cmd.env("STCK_TEST_FEATURE_BRANCH_BASE", "main");
+    cmd.env("STCK_TEST_MISSING_REMOTE_BRANCH", "feature-child");
+    cmd.arg("push");
+
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "$ git push --force-with-lease origin feature-child",
+        ))
+        .stdout(predicate::str::contains(
+            "Push succeeded. Pushed 1 branch(es) and applied 0 PR base update(s) in this run.",
+        ));
+
+    let log = fs::read_to_string(&log_path).expect("push log should exist");
+    assert!(
+        log.contains("push --force-with-lease origin feature-child"),
+        "push should publish a branch whose remote ref is absent"
+    );
+}
+
+#[test]
+fn push_fails_closed_when_remote_ref_lookup_errors() {
+    let (temp, mut cmd) = stck_cmd_with_stubbed_tools();
+    let log_path = log_path(&temp, "stck-push-ref-lookup-error.log");
+    cmd.env("STCK_TEST_LOG", log_path.as_os_str());
+    cmd.env("STCK_TEST_FEATURE_BRANCH_BASE", "main");
+    cmd.env("STCK_TEST_NEEDS_PUSH_BRANCH", "feature-child");
+    cmd.env(
+        "STCK_TEST_REF_LOOKUP_FAIL",
+        "refs/remotes/origin/feature-child",
+    );
+    cmd.arg("push");
+
+    cmd.assert().code(1).stderr(predicate::str::contains(
+        "error: failed to verify git reference `refs/remotes/origin/feature-child`; ensure this is a git repository",
+    ));
+
+    let log = fs::read_to_string(&log_path).unwrap_or_default();
+    assert!(
+        !log.contains("push --force-with-lease origin feature-child"),
+        "push must not treat a ref lookup failure as a missing remote branch"
+    );
+}
+
+#[test]
 fn sync_then_push_after_squash_merge_produces_correct_retargets() {
     let (temp, mut sync) = stck_cmd_with_stubbed_tools();
     let log_path = log_path(&temp, "sync-push-squash.log");

--- a/tests/real_git.rs
+++ b/tests/real_git.rs
@@ -88,6 +88,46 @@ fn submit_discovers_a_remote_parent_without_its_local_branch() {
 }
 
 #[test]
+fn status_and_push_handle_a_missing_remote_branch() {
+    let repo = RealGitRepo::new();
+    repo.create_branch("feature-missing-remote");
+    repo.commit_file("feature.txt", "feature\n", "Add local feature");
+    repo.write_pr_response(
+        "feature-missing-remote",
+        r#"{"number":103,"headRefName":"feature-missing-remote","baseRefName":"main","state":"OPEN"}"#,
+    );
+    repo.write_children_response("feature-missing-remote", "[]");
+
+    let mut status = repo.stck_cmd();
+    status.arg("status");
+    status
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "* feature-missing-remote PR #103 OPEN base=main [needs_push]",
+        ))
+        .stdout(predicate::str::contains(
+            "Summary: 0 needs_sync, 1 needs_push, 0 base_mismatch",
+        ));
+
+    let mut push = repo.stck_cmd();
+    push.arg("push");
+    push.assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "$ git push --force-with-lease origin feature-missing-remote",
+        ))
+        .stdout(predicate::str::contains(
+            "Push succeeded. Pushed 1 branch(es) and applied 0 PR base update(s) in this run.",
+        ));
+
+    assert_eq!(
+        repo.local_sha("refs/heads/feature-missing-remote"),
+        repo.remote_sha("feature-missing-remote")
+    );
+}
+
+#[test]
 fn sync_rebases_a_real_linear_stack_after_main_advances() {
     let repo = RealGitRepo::new();
 


### PR DESCRIPTION
## Summary

Make `stck push` fulfill the `needs_push` state when a stack branch has no fetched remote ref.

Existing remote branches retain the ancestry safety check. Missing remote refs can now be created using `--force-with-lease`, while ref lookup failures remain fail-closed.

Stack position: 4 of 10. Base: `detect-parent-drift`. Parent PR: #52.

## Changelist

- `src/commands.rs` — skip the ancestry check only when the remote ref is confirmed absent
- `tests/push.rs` — cover missing remote publication and ref lookup failures
- `tests/real_git.rs` — verify `status` reports the condition and `push` repairs it against a real bare origin
- `tests/harness/mod.rs` — support explicit ref lookup failures
- `USAGE.md` — document missing remote branch behavior