### PR TITLE
Add stack context to PR bodies

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ stck push
 
 `stck submit` auto-detects the most likely stack parent when `--base` is omitted. If discovery can inspect every candidate but finds no parent PR, it falls back to the repository default branch. Missing refs or failed ancestry checks stop discovery instead of silently selecting the default branch. In larger repositories, discovery currently inspects up to the first 100 open PRs, so `--base <branch>` remains the reliable escape hatch.
 
+PRs created by `new` or `submit` include a compact body identifying their root/child position and base branch.
+
 Git subcommand entrypoint is also installed (when installed via homebrew):
 
 ```bash

--- a/USAGE.md
+++ b/USAGE.md
@@ -78,6 +78,7 @@ stck submit --base feature-a
 - Parent auto-discovery currently inspects up to the first 100 open PRs, so `--base` is the reliable override in larger repositories.
 - Use `--base` any time you want to target a stack parent branch explicitly.
 - If the current branch already has a PR, it reports a no-op.
+- New PRs include a compact body identifying their root/child position and base branch.
 
 ### 3. Sync local stack after upstream changes
 

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -208,10 +208,12 @@ pub(crate) fn run_new(preflight: &env::PreflightContext, new_branch: &str) -> Ex
                 }
             };
             println!(
-                "$ gh pr create --base {} --head {} --title {} --body \"\"",
+                "$ gh pr create --base {} --head {} --title {} --body \"<stack context>\"",
                 bootstrap_base, current_branch, current_branch
             );
-            if let Err(message) = github::create_pr(&bootstrap_base, current_branch, current_branch)
+            let body = github::stack_pr_body(&bootstrap_base, &preflight.default_branch);
+            if let Err(message) =
+                github::create_pr(&bootstrap_base, current_branch, current_branch, &body)
             {
                 eprintln!("error: {message}");
                 return ExitCode::from(1);
@@ -247,10 +249,11 @@ pub(crate) fn run_new(preflight: &env::PreflightContext, new_branch: &str) -> Ex
     }
 
     println!(
-        "$ gh pr create --base {} --head {} --title {} --body \"\"",
+        "$ gh pr create --base {} --head {} --title {} --body \"<stack context>\"",
         pr_base_branch, new_branch, new_branch
     );
-    if let Err(message) = github::create_pr(pr_base_branch, new_branch, new_branch) {
+    let body = github::stack_pr_body(pr_base_branch, &preflight.default_branch);
+    if let Err(message) = github::create_pr(pr_base_branch, new_branch, new_branch, &body) {
         eprintln!("error: {message}");
         return ExitCode::from(1);
     }
@@ -389,10 +392,11 @@ pub(crate) fn run_submit(
     };
 
     println!(
-        "$ gh pr create --base {} --head {} --title {} --body \"\"",
+        "$ gh pr create --base {} --head {} --title {} --body \"<stack context>\"",
         base, current_branch, current_branch
     );
-    if let Err(message) = github::create_pr(base, current_branch, current_branch) {
+    let body = github::stack_pr_body(base, &preflight.default_branch);
+    if let Err(message) = github::create_pr(base, current_branch, current_branch, &body) {
         eprintln!("error: {message}");
         return ExitCode::from(1);
     }

--- a/src/github.rs
+++ b/src/github.rs
@@ -174,11 +174,11 @@ pub fn pr_exists_for_head(branch: &str) -> Result<bool, String> {
     }
 }
 
-/// Create a pull request with the given base, head, and title.
-pub fn create_pr(base: &str, head: &str, title: &str) -> Result<(), String> {
+/// Create a pull request with the given base, head, title, and body.
+pub fn create_pr(base: &str, head: &str, title: &str, body: &str) -> Result<(), String> {
     let output = Command::new("gh")
         .args([
-            "pr", "create", "--base", base, "--head", head, "--title", title, "--body", "",
+            "pr", "create", "--base", base, "--head", head, "--title", title, "--body", body,
         ])
         .output()
         .map_err(|_| "failed to run `gh pr create`; ensure GitHub CLI is installed".to_string())?;
@@ -191,6 +191,29 @@ pub fn create_pr(base: &str, head: &str, title: &str) -> Result<(), String> {
             &output.stderr,
         ))
     }
+}
+
+/// Build the deterministic stack context included in newly created PRs.
+pub fn stack_pr_body(base: &str, default_branch: &str) -> String {
+    let position = if base == default_branch {
+        "Root"
+    } else {
+        "Child"
+    };
+    let base = markdown_code_span(base);
+    format!(
+        "This pull request is part of a stack.\n\n- **Position:** {position}\n- **Base:** {base}"
+    )
+}
+
+fn markdown_code_span(value: &str) -> String {
+    let longest_run = value
+        .split(|character| character != '`')
+        .map(str::len)
+        .max()
+        .unwrap_or(0);
+    let fence = "`".repeat(longest_run + 1);
+    format!("{fence}{value}{fence}")
 }
 
 /// List same-repository head branches for open pull requests.
@@ -387,7 +410,7 @@ pub fn build_linear_stack(
 
 #[cfg(test)]
 mod tests {
-    use super::{build_linear_stack, PrState, PullRequest};
+    use super::{build_linear_stack, stack_pr_body, PrState, PullRequest};
 
     fn pr(number: u64, head: &str, base: &str) -> PullRequest {
         PullRequest {
@@ -396,6 +419,30 @@ mod tests {
             base_ref_name: base.to_string(),
             state: PrState::Open,
         }
+    }
+
+    #[test]
+    fn builds_root_pr_stack_context() {
+        assert_eq!(
+            stack_pr_body("main", "main"),
+            "This pull request is part of a stack.\n\n- **Position:** Root\n- **Base:** `main`"
+        );
+    }
+
+    #[test]
+    fn builds_child_pr_stack_context() {
+        assert_eq!(
+            stack_pr_body("feature-base", "main"),
+            "This pull request is part of a stack.\n\n- **Position:** Child\n- **Base:** `feature-base`"
+        );
+    }
+
+    #[test]
+    fn preserves_backticks_in_stack_base_branch() {
+        assert_eq!(
+            stack_pr_body("feature`base", "main"),
+            "This pull request is part of a stack.\n\n- **Position:** Child\n- **Base:** ``feature`base``"
+        );
     }
 
     #[test]

--- a/tests/harness/mod.rs
+++ b/tests/harness/mod.rs
@@ -548,17 +548,19 @@ fi
 if [[ "${1:-}" == "pr" && "${2:-}" == "create" ]]; then
   base=""
   head=""
+  body=""
   while [[ $# -gt 0 ]]; do
     case "$1" in
       --base) base="${2:-}"; shift 2 ;;
       --head) head="${2:-}"; shift 2 ;;
       --title) shift 2 ;;
-      --body) shift 2 ;;
+      --body) body="${2:-}"; shift 2 ;;
       *) shift ;;
     esac
   done
   if [[ -n "${STCK_TEST_LOG:-}" ]]; then
-    echo "pr create --base ${base} --head ${head}" >> "${STCK_TEST_LOG}"
+    printf 'pr create --base %s --head %s\npr body --head %s\n%s\n' \
+      "${base}" "${head}" "${head}" "${body}" >> "${STCK_TEST_LOG}"
   fi
   if [[ "${STCK_TEST_PR_CREATE_FAIL_HEAD:-}" == "${head}" ]]; then
     exit 1

--- a/tests/new.rs
+++ b/tests/new.rs
@@ -33,12 +33,12 @@ fn new_bootstraps_current_branch_then_creates_stacked_branch_and_pr() {
         .success()
         .stdout(predicate::str::contains("$ git push -u origin feature-branch"))
         .stdout(predicate::str::contains(
-            "$ gh pr create --base main --head feature-branch --title feature-branch --body \"\"",
+            "$ gh pr create --base main --head feature-branch --title feature-branch --body \"<stack context>\"",
         ))
         .stdout(predicate::str::contains("$ git checkout -b feature-next"))
         .stdout(predicate::str::contains("$ git push -u origin feature-next"))
         .stdout(predicate::str::contains(
-            "$ gh pr create --base feature-branch --head feature-next --title feature-next --body \"\"",
+            "$ gh pr create --base feature-branch --head feature-next --title feature-next --body \"<stack context>\"",
         ))
         .stdout(predicate::str::contains(
             "Created branch feature-next and opened a stacked PR targeting feature-branch.",
@@ -165,7 +165,7 @@ fn new_from_default_branch_skips_default_branch_bootstrap() {
             "$ git push -u origin feature-next",
         ))
         .stdout(predicate::str::contains(
-            "$ gh pr create --base main --head feature-next --title feature-next --body \"\"",
+            "$ gh pr create --base main --head feature-next --title feature-next --body \"<stack context>\"",
         ))
         .stdout(predicate::str::contains(
             "Created branch feature-next and opened a stacked PR targeting main.",

--- a/tests/real_git.rs
+++ b/tests/real_git.rs
@@ -56,6 +56,9 @@ fn submit_pushes_a_real_branch_before_creating_its_pr() {
     let gh_log = repo.gh_log();
     assert!(gh_log.contains("pr view feature-submit --json number"));
     assert!(gh_log.contains("pr create --base main --head feature-submit"));
+    assert!(gh_log.contains(
+        "This pull request is part of a stack.\n\n- **Position:** Root\n- **Base:** `main`"
+    ));
 }
 
 #[test]
@@ -85,6 +88,9 @@ fn submit_discovers_a_remote_parent_without_its_local_branch() {
     let gh_log = repo.gh_log();
     assert!(gh_log.contains("pr list --state open --limit 100"));
     assert!(gh_log.contains("pr create --base feature-base --head feature-child"));
+    assert!(gh_log.contains(
+        "This pull request is part of a stack.\n\n- **Position:** Child\n- **Base:** `feature-base`"
+    ));
 }
 
 #[test]

--- a/tests/submit.rs
+++ b/tests/submit.rs
@@ -14,7 +14,7 @@ fn submit_creates_pr_with_base_override() {
     cmd.assert()
         .success()
         .stdout(predicate::str::contains(
-            "$ gh pr create --base feature-base --head feature-branch --title feature-branch --body \"\"",
+            "$ gh pr create --base feature-base --head feature-branch --title feature-branch --body \"<stack context>\"",
         ))
         .stdout(predicate::str::contains(
             "Created PR for feature-branch targeting feature-base.",
@@ -22,6 +22,9 @@ fn submit_creates_pr_with_base_override() {
 
     let log = fs::read_to_string(&log_path).expect("submit log should exist");
     assert!(log.contains("pr create --base feature-base --head feature-branch"));
+    assert!(log.contains(
+        "pr body --head feature-branch\nThis pull request is part of a stack.\n\n- **Position:** Child\n- **Base:** `feature-base`"
+    ));
 }
 
 #[test]
@@ -37,8 +40,13 @@ fn submit_defaults_base_to_default_branch() {
             "No --base provided. Defaulting PR base to main.",
         ))
         .stdout(predicate::str::contains(
-            "$ gh pr create --base main --head feature-branch --title feature-branch --body \"\"",
+            "$ gh pr create --base main --head feature-branch --title feature-branch --body \"<stack context>\"",
         ));
+
+    let log = fs::read_to_string(&log_path).expect("submit log should exist");
+    assert!(log.contains(
+        "pr body --head feature-branch\nThis pull request is part of a stack.\n\n- **Position:** Root\n- **Base:** `main`"
+    ));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Give every pull request created by `stck new` or `stck submit` deterministic stack context.

Generated bodies identify the PR as a root or child and show its base branch using the approved compact Markdown format. Body generation remains separate from GitHub command execution so future customization from issue #49 can be added cleanly.

Stack position: 5 of 10. Base: `push-missing-remote-branches`. Parent PR: #53.

## Changelist

- `src/github.rs` — generate safe root/child stack metadata and pass explicit bodies to `gh`
- `src/commands.rs` — apply generated context across every PR creation path
- `tests/new.rs` and `tests/submit.rs` — verify generated-body command behavior and exact metadata
- `tests/real_git.rs` and `tests/harness/mod.rs` — capture and verify actual `gh` body arguments
- `README.md` and `USAGE.md` — document the generated PR context