### PR TITLE
Target parent discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ stck push
 
 `stck new <branch>` works both when starting from the default branch and when stacking on top of an existing branch.
 
-`stck submit` auto-detects the most likely stack parent when `--base` is omitted. If discovery can inspect every candidate but finds no parent PR, it falls back to the repository default branch. Missing refs or failed ancestry checks stop discovery instead of silently selecting the default branch. In larger repositories, discovery currently inspects up to the first 100 open PRs, so `--base <branch>` remains the reliable escape hatch.
+`stck submit` auto-detects the most likely stack parent when `--base` is omitted. It fetches `origin`, checks ancestor branch refs, and uses targeted GitHub queries to confirm open PRs without a repository-wide result limit. If discovery checks every candidate but finds no parent PR, it falls back to the repository default branch. Missing refs or failed ancestry checks stop discovery instead of silently selecting the default branch.
 
 PRs created by `new` or `submit` include a compact body identifying their root/child position and base branch.
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -72,10 +72,9 @@ stck submit --base feature-a
 
 `submit` creates a PR for the current branch when one does not exist.
 
-- If no `--base` is provided, `stck` first tries to auto-detect the stack parent from open PR metadata.
+- If no `--base` is provided, `stck` first checks fetched ancestor branches and uses targeted open-PR queries to auto-detect the stack parent.
 - If discovery checks every available candidate and finds no parent PR, `stck` falls back to the repository default branch.
 - If GitHub lookup, ref resolution, or an ancestry check fails, `stck` errors and tells you to retry or pass `--base <branch>` explicitly.
-- Parent auto-discovery currently inspects up to the first 100 open PRs, so `--base` is the reliable override in larger repositories.
 - Use `--base` any time you want to target a stack parent branch explicitly.
 - If the current branch already has a PR, it reports a no-op.
 - New PRs include a compact body identifying their root/child position and base branch.
@@ -134,5 +133,5 @@ stck push
 ## Notes
 
 - `stck` currently assumes a linear stack and fails fast for non-linear graphs.
-- Parent auto-discovery for `new`/`submit` currently scans up to 100 open PRs before giving up. In larger repositories, pass `--base <branch>` explicitly.
+- Parent auto-discovery for `new`/`submit` checks fetched `origin` branches and queries GitHub only for ancestor candidates, avoiding a repository-wide PR result limit.
 - If a rebase conflict happens during `sync`, resolve conflicts with normal Git workflow, then continue and rerun `stck sync` as needed.

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -277,9 +277,9 @@ fn parent_discovery_error(branch: &str, message: &str) -> String {
 /// GitHub, ref-resolution, or ancestry-check failure is returned separately so
 /// callers cannot silently create a PR against the default branch.
 fn discover_parent_base(branch: &str) -> Result<Option<String>, String> {
-    let candidate_branches = github::list_open_pr_head_branches()
-        .map_err(|message| parent_discovery_error(branch, &message))?;
     gitops::fetch_origin().map_err(|message| parent_discovery_error(branch, &message))?;
+    let candidate_branches = gitops::list_origin_branches()
+        .map_err(|message| parent_discovery_error(branch, &message))?;
 
     let branch_ref = format!("refs/heads/{branch}");
     let mut best: Option<(String, String)> = None;
@@ -294,7 +294,10 @@ fn discover_parent_base(branch: &str) -> Result<Option<String>, String> {
         let is_ancestor = gitops::is_ancestor(&candidate_ref, &branch_ref)
             .map_err(|message| parent_discovery_error(branch, &message))?;
 
-        if is_ancestor {
+        if is_ancestor
+            && github::has_open_pr_for_head(&candidate)
+                .map_err(|message| parent_discovery_error(branch, &message))?
+        {
             if let Some((_, current_best_ref)) = &best {
                 let is_closer_parent = gitops::is_ancestor(current_best_ref, &candidate_ref)
                     .map_err(|message| parent_discovery_error(branch, &message))?;

--- a/src/github.rs
+++ b/src/github.rs
@@ -216,21 +216,22 @@ fn markdown_code_span(value: &str) -> String {
     format!("{fence}{value}{fence}")
 }
 
-/// List same-repository head branches for open pull requests.
+/// Return whether `branch` is the head of an open same-repository pull request.
 ///
-/// This currently relies on `gh pr list --limit 100`, so callers should treat
-/// it as a best-effort discovery source rather than a complete repository-wide
-/// index in very large repositories. Cross-repository pull requests are
-/// excluded because their head branches are not available through `origin`.
-pub fn list_open_pr_head_branches() -> Result<Vec<String>, String> {
+/// This uses a targeted query so parent discovery does not depend on a bounded
+/// repository-wide PR listing. Cross-repository results are excluded because
+/// their head branches are not available through `origin`.
+pub fn has_open_pr_for_head(branch: &str) -> Result<bool, String> {
     let output = Command::new("gh")
         .args([
             "pr",
             "list",
+            "--head",
+            branch,
             "--state",
             "open",
             "--limit",
-            "100",
+            "1",
             "--json",
             "headRefName,isCrossRepository",
         ])
@@ -239,7 +240,7 @@ pub fn list_open_pr_head_branches() -> Result<Vec<String>, String> {
 
     if !output.status.success() {
         return Err(with_stderr(
-            "failed to list open pull requests from GitHub",
+            &format!("failed to query open pull request for branch {branch}"),
             &output.stderr,
         ));
     }
@@ -247,10 +248,8 @@ pub fn list_open_pr_head_branches() -> Result<Vec<String>, String> {
     let prs = serde_json::from_slice::<Vec<OpenPullRequestHead>>(&output.stdout)
         .map_err(|_| "failed to parse PR metadata from GitHub CLI output".to_string())?;
     Ok(prs
-        .into_iter()
-        .filter(|pr| !pr.is_cross_repository)
-        .map(|pr| pr.head_ref_name)
-        .collect())
+        .iter()
+        .any(|pr| !pr.is_cross_repository && pr.head_ref_name == branch))
 }
 
 fn fetch_pr_for_branch(branch: &str) -> Result<PullRequest, String> {

--- a/src/gitops.rs
+++ b/src/gitops.rs
@@ -24,6 +24,37 @@ pub fn fetch_origin() -> Result<(), String> {
     }
 }
 
+/// List branch names advertised by the fetched `origin` remote.
+///
+/// The symbolic `origin/HEAD` ref is excluded because it is an alias for the
+/// default branch rather than a candidate stack branch.
+pub fn list_origin_branches() -> Result<Vec<String>, String> {
+    let output = Command::new("git")
+        .args([
+            "for-each-ref",
+            "--format=%(refname:strip=3)",
+            "refs/remotes/origin",
+        ])
+        .output()
+        .map_err(|_| "failed to run `git for-each-ref`".to_string())?;
+
+    if !output.status.success() {
+        return Err(with_stderr(
+            "failed to list branches from `origin`",
+            &output.stderr,
+        ));
+    }
+
+    let mut branches = String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .filter(|branch| !branch.is_empty() && *branch != "HEAD")
+        .map(str::to_string)
+        .collect::<Vec<_>>();
+    branches.sort();
+    branches.dedup();
+    Ok(branches)
+}
+
 /// Return whether the local branch head differs from `origin/<branch>`.
 ///
 /// Missing remote refs are treated as needing a push so newly created branches

--- a/tests/harness/mod.rs
+++ b/tests/harness/mod.rs
@@ -70,6 +70,19 @@ if [[ "${1:-}" == "fetch" && "${2:-}" == "origin" ]]; then
   exit 0
 fi
 
+if [[ "${1:-}" == "for-each-ref" && "${2:-}" == "--format=%(refname:strip=3)" && "${3:-}" == "refs/remotes/origin" ]]; then
+  if [[ "${STCK_TEST_LIST_ORIGIN_BRANCHES_FAIL:-0}" == "1" ]]; then
+    echo "failed to enumerate remote refs" >&2
+    exit 1
+  fi
+  if [[ -n "${STCK_TEST_ORIGIN_BRANCHES:-}" ]]; then
+    printf '%s\n' "${STCK_TEST_ORIGIN_BRANCHES}"
+  else
+    printf '%s\n' main feature-base feature-branch feature-child
+  fi
+  exit 0
+fi
+
 if [[ "${1:-}" == "rev-parse" && "${2:-}" == "--verify" ]]; then
   ref="${3:-}"
 
@@ -415,6 +428,9 @@ if [[ "${1:-}" == "repo" && "${2:-}" == "view" ]]; then
 fi
 
 if [[ "${1:-}" == "pr" && "${2:-}" == "list" ]]; then
+  if [[ -n "${STCK_TEST_LOG:-}" ]]; then
+    echo "$*" >> "${STCK_TEST_LOG}"
+  fi
   if [[ "${STCK_TEST_PR_LIST_FAIL:-0}" == "1" ]]; then
     echo "failed to list pull requests" >&2
     exit 1
@@ -422,6 +438,7 @@ if [[ "${1:-}" == "pr" && "${2:-}" == "list" ]]; then
 
   pr_list_state="all"
   pr_list_base=""
+  pr_list_head=""
   for ((i=1; i<=$#; i++)); do
     if [[ "${!i}" == "--state" ]]; then
       next=$((i+1))
@@ -430,6 +447,10 @@ if [[ "${1:-}" == "pr" && "${2:-}" == "list" ]]; then
     if [[ "${!i}" == "--base" ]]; then
       next=$((i+1))
       pr_list_base="${!next}"
+    fi
+    if [[ "${!i}" == "--head" ]]; then
+      next=$((i+1))
+      pr_list_head="${!next}"
     fi
   done
 
@@ -456,6 +477,15 @@ if [[ "${1:-}" == "pr" && "${2:-}" == "list" ]]; then
       feature-branch) echo '[{"number":102,"headRefName":"feature-child","baseRefName":"feature-branch","state":"OPEN"}]' ;;
       *) echo '[]' ;;
     esac
+    exit 0
+  fi
+
+  if [[ -n "${pr_list_head}" && "${pr_list_state}" == "open" ]]; then
+    if [[ -n "${STCK_TEST_OPEN_PRS_JSON:-}" ]]; then
+      echo "${STCK_TEST_OPEN_PRS_JSON}"
+    else
+      echo '[]'
+    fi
     exit 0
   fi
 
@@ -661,14 +691,19 @@ fi
 
 if [[ "${1:-}" == "pr" && "${2:-}" == "list" ]]; then
   base=""
+  head=""
   while [[ $# -gt 0 ]]; do
     case "$1" in
       --base) base="${2:-}"; shift 2 ;;
+      --head) head="${2:-}"; shift 2 ;;
       *) shift ;;
     esac
   done
 
-  if [[ -n "${base}" ]]; then
+  if [[ -n "${head}" ]]; then
+    safe_head="${head//\//__}"
+    response="${STCK_REAL_GH_RESPONSES}/pr-list-head-${safe_head}.json"
+  elif [[ -n "${base}" ]]; then
     safe_base="${base//\//__}"
     response="${STCK_REAL_GH_RESPONSES}/pr-list-base-${safe_base}.json"
   else
@@ -840,6 +875,15 @@ exit 1
             json,
         )
         .expect("gh children response should be written");
+    }
+
+    pub fn write_open_pr_head_response(&self, head: &str, json: &str) {
+        let head = head.replace('/', "__");
+        fs::write(
+            self.gh_responses.join(format!("pr-list-head-{head}.json")),
+            json,
+        )
+        .expect("gh head response should be written");
     }
 
     pub fn write_open_prs_response(&self, json: &str) {

--- a/tests/new.rs
+++ b/tests/new.rs
@@ -139,13 +139,13 @@ fn new_prefers_remote_parent_when_local_parent_has_drifted() {
 }
 
 #[test]
-fn new_fails_when_parent_discovery_errors() {
+fn new_fails_when_targeted_parent_query_errors() {
     let (_temp, mut cmd) = stck_cmd_with_stubbed_tools();
     cmd.env("STCK_TEST_PR_LIST_FAIL", "1");
     cmd.args(["new", "feature-next"]);
 
     cmd.assert().code(1).stderr(predicate::str::contains(
-        "error: could not auto-detect stack parent for feature-branch: failed to list open pull requests from GitHub; stderr: failed to list pull requests; retry or pass `--base <branch>` explicitly",
+        "error: could not auto-detect stack parent for feature-branch: failed to query open pull request for branch feature-base; stderr: failed to list pull requests; retry or pass `--base <branch>` explicitly",
     ));
 }
 

--- a/tests/real_git.rs
+++ b/tests/real_git.rs
@@ -71,7 +71,10 @@ fn submit_discovers_a_remote_parent_without_its_local_branch() {
     repo.create_branch("feature-child");
     repo.commit_file("child.txt", "child\n", "Add child feature");
     repo.delete_local_branch("feature-base");
-    repo.write_open_prs_response(r#"[{"headRefName":"feature-base","isCrossRepository":false}]"#);
+    repo.write_open_pr_head_response(
+        "feature-base",
+        r#"[{"headRefName":"feature-base","isCrossRepository":false}]"#,
+    );
 
     let mut cmd = repo.stck_cmd();
     cmd.arg("submit");
@@ -86,7 +89,13 @@ fn submit_discovers_a_remote_parent_without_its_local_branch() {
         ));
 
     let gh_log = repo.gh_log();
-    assert!(gh_log.contains("pr list --state open --limit 100"));
+    assert!(gh_log.contains(
+        "pr list --head feature-base --state open --limit 1 --json headRefName,isCrossRepository"
+    ));
+    assert!(
+        !gh_log.contains("pr list --state open --limit 100"),
+        "parent discovery must not depend on a bounded repository-wide PR scan"
+    );
     assert!(gh_log.contains("pr create --base feature-base --head feature-child"));
     assert!(gh_log.contains(
         "This pull request is part of a stack.\n\n- **Position:** Child\n- **Base:** `feature-base`"

--- a/tests/submit.rs
+++ b/tests/submit.rs
@@ -66,13 +66,24 @@ fn submit_falls_back_to_default_when_no_parent_pr() {
 }
 
 #[test]
-fn submit_fails_when_parent_discovery_errors() {
+fn submit_fails_when_targeted_parent_query_errors() {
     let (_temp, mut cmd) = stck_cmd_with_stubbed_tools();
     cmd.env("STCK_TEST_PR_LIST_FAIL", "1");
     cmd.arg("submit");
 
     cmd.assert().code(1).stderr(predicate::str::contains(
-        "error: could not auto-detect stack parent for feature-branch: failed to list open pull requests from GitHub; stderr: failed to list pull requests; retry or pass `--base <branch>` explicitly",
+        "error: could not auto-detect stack parent for feature-branch: failed to query open pull request for branch feature-base; stderr: failed to list pull requests; retry or pass `--base <branch>` explicitly",
+    ));
+}
+
+#[test]
+fn submit_fails_when_origin_branches_cannot_be_listed() {
+    let (_temp, mut cmd) = stck_cmd_with_stubbed_tools();
+    cmd.env("STCK_TEST_LIST_ORIGIN_BRANCHES_FAIL", "1");
+    cmd.arg("submit");
+
+    cmd.assert().code(1).stderr(predicate::str::contains(
+        "error: could not auto-detect stack parent for feature-branch: failed to list branches from `origin`; stderr: failed to enumerate remote refs; retry or pass `--base <branch>` explicitly",
     ));
 }
 
@@ -185,6 +196,13 @@ fn submit_discovers_parent_base_for_stacked_branch() {
         ));
 
     let log = fs::read_to_string(&log_path).expect("submit log should exist");
+    assert!(log.contains(
+        "pr list --head feature-base --state open --limit 1 --json headRefName,isCrossRepository"
+    ));
+    assert!(
+        !log.contains("pr list --state open --limit 100"),
+        "submit must use targeted parent queries"
+    );
     assert!(log.contains("pr create --base feature-base --head feature-branch"));
 }
 


### PR DESCRIPTION
## Summary

Replace the bounded repository-wide parent scan with targeted discovery against fetched ancestor branches.

`stck new` and `stck submit` now enumerate `origin` refs, filter candidates using Git ancestry, and query GitHub only for plausible open-PR heads. This removes the 100-open-PR scale ceiling while preserving fail-closed discovery errors.

Stack position: 6 of 10. Base: `add-stack-context-to-pr-bodies`. Parent PR: #54.

## Changelist

- `src/gitops.rs` — enumerate fetched `origin` branch refs deterministically
- `src/github.rs` — query open PR state for a specific candidate head
- `src/commands.rs` — combine local ancestry filtering with targeted GitHub confirmation
- `tests/` — cover targeted lookup commands, ref-list failures, and real-Git discovery
- `README.md` and `USAGE.md` — remove the obsolete 100-PR limitation