### PR TITLE
Structure PR lookups

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -295,7 +295,7 @@ fn discover_parent_base(branch: &str) -> Result<Option<String>, String> {
             .map_err(|message| parent_discovery_error(branch, &message))?;
 
         if is_ancestor
-            && github::has_open_pr_for_head(&candidate)
+            && github::pr_exists_for_head(&candidate)
                 .map_err(|message| parent_discovery_error(branch, &message))?
         {
             if let Some((_, current_best_ref)) = &best {

--- a/src/github.rs
+++ b/src/github.rs
@@ -50,6 +50,29 @@ struct OpenPullRequestHead {
     is_cross_repository: bool,
 }
 
+#[derive(Debug, Deserialize)]
+struct PullRequestCandidate {
+    number: u64,
+    #[serde(rename = "headRefName")]
+    head_ref_name: String,
+    #[serde(rename = "baseRefName")]
+    base_ref_name: String,
+    state: PrState,
+    #[serde(rename = "isCrossRepository", default)]
+    is_cross_repository: bool,
+}
+
+impl From<PullRequestCandidate> for PullRequest {
+    fn from(candidate: PullRequestCandidate) -> Self {
+        Self {
+            number: candidate.number,
+            head_ref_name: candidate.head_ref_name,
+            base_ref_name: candidate.base_ref_name,
+            state: candidate.state,
+        }
+    }
+}
+
 /// Discover the full linear stack surrounding `current_branch`.
 ///
 /// The returned list is ordered from the stack root to the highest descendant
@@ -143,35 +166,42 @@ pub fn retarget_pr_base(branch: &str, new_base: &str) -> Result<(), String> {
     }
 }
 
-/// Return whether a pull request already exists for `branch`.
+/// Return whether an open same-repository pull request exists for `branch`.
 ///
-/// "No pull request found" responses are treated as `Ok(false)`. Other `gh`
-/// failures are surfaced as actionable errors.
+/// An empty structured result is treated as `Ok(false)`. Other `gh` failures
+/// are surfaced as actionable errors. Cross-repository results with the same
+/// head name are ignored.
 pub fn pr_exists_for_head(branch: &str) -> Result<bool, String> {
     let output = Command::new("gh")
-        .args(["pr", "view", branch, "--json", "number"])
+        .args([
+            "pr",
+            "list",
+            "--head",
+            branch,
+            "--state",
+            "open",
+            "--limit",
+            "100",
+            "--json",
+            "headRefName,isCrossRepository",
+        ])
         .output()
-        .map_err(|_| "failed to run `gh pr view`; ensure GitHub CLI is installed".to_string())?;
+        .map_err(|_| "failed to run `gh pr list`; ensure GitHub CLI is installed".to_string())?;
 
-    match output.status.code() {
-        Some(0) => Ok(true),
-        Some(_) => {
-            let stderr = String::from_utf8_lossy(&output.stderr).to_lowercase();
-            if stderr.contains("no pull requests found")
-                || stderr.contains("could not resolve to a pull request")
-            {
-                Ok(false)
-            } else {
-                Err(with_stderr(
-                    &format!(
-                        "failed to check PR for branch {branch}; ensure `gh auth status` succeeds and retry"
-                    ),
-                    &output.stderr,
-                ))
-            }
-        }
-        None => Err("failed to determine PR presence for branch".to_string()),
+    if !output.status.success() {
+        return Err(with_stderr(
+            &format!(
+                "failed to check PR for branch {branch}; ensure `gh auth status` succeeds and retry"
+            ),
+            &output.stderr,
+        ));
     }
+
+    let prs = serde_json::from_slice::<Vec<OpenPullRequestHead>>(&output.stdout)
+        .map_err(|_| format!("failed to parse PR lookup metadata for branch {branch}"))?;
+    Ok(prs
+        .iter()
+        .any(|pr| !pr.is_cross_repository && pr.head_ref_name == branch))
 }
 
 /// Create a pull request with the given base, head, title, and body.
@@ -216,12 +246,7 @@ fn markdown_code_span(value: &str) -> String {
     format!("{fence}{value}{fence}")
 }
 
-/// Return whether `branch` is the head of an open same-repository pull request.
-///
-/// This uses a targeted query so parent discovery does not depend on a bounded
-/// repository-wide PR listing. Cross-repository results are excluded because
-/// their head branches are not available through `origin`.
-pub fn has_open_pr_for_head(branch: &str) -> Result<bool, String> {
+fn fetch_pr_for_branch(branch: &str) -> Result<PullRequest, String> {
     let output = Command::new("gh")
         .args([
             "pr",
@@ -229,58 +254,58 @@ pub fn has_open_pr_for_head(branch: &str) -> Result<bool, String> {
             "--head",
             branch,
             "--state",
-            "open",
+            "all",
             "--limit",
-            "1",
+            "100",
             "--json",
-            "headRefName,isCrossRepository",
+            "number,headRefName,baseRefName,state,isCrossRepository",
         ])
         .output()
         .map_err(|_| "failed to run `gh pr list`; ensure GitHub CLI is installed".to_string())?;
 
     if !output.status.success() {
         return Err(with_stderr(
-            &format!("failed to query open pull request for branch {branch}"),
-            &output.stderr,
-        ));
-    }
-
-    let prs = serde_json::from_slice::<Vec<OpenPullRequestHead>>(&output.stdout)
-        .map_err(|_| "failed to parse PR metadata from GitHub CLI output".to_string())?;
-    Ok(prs
-        .iter()
-        .any(|pr| !pr.is_cross_repository && pr.head_ref_name == branch))
-}
-
-fn fetch_pr_for_branch(branch: &str) -> Result<PullRequest, String> {
-    let output = Command::new("gh")
-        .args([
-            "pr",
-            "view",
-            branch,
-            "--json",
-            "number,headRefName,baseRefName,state",
-        ])
-        .output()
-        .map_err(|_| "failed to run `gh pr view`; ensure GitHub CLI is installed".to_string())?;
-
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr).to_lowercase();
-        if stderr.contains("no pull requests found")
-            || stderr.contains("could not resolve to a pull request")
-        {
-            return Err(format!(
-                "no PR found for branch {branch}; create a PR first"
-            ));
-        }
-        return Err(with_stderr(
             &format!("failed to fetch PR for branch {branch}"),
             &output.stderr,
         ));
     }
 
-    serde_json::from_slice::<PullRequest>(&output.stdout)
-        .map_err(|_| format!("failed to parse PR metadata for branch {branch}"))
+    let candidates = serde_json::from_slice::<Vec<PullRequestCandidate>>(&output.stdout)
+        .map_err(|_| format!("failed to parse PR metadata for branch {branch}"))?;
+    select_pr_for_head(candidates, branch)
+}
+
+fn select_pr_for_head(
+    candidates: Vec<PullRequestCandidate>,
+    branch: &str,
+) -> Result<PullRequest, String> {
+    let mut candidates = candidates
+        .into_iter()
+        .filter(|pr| !pr.is_cross_repository && pr.head_ref_name == branch)
+        .collect::<Vec<_>>();
+
+    let open_count = candidates
+        .iter()
+        .filter(|pr| pr.state == PrState::Open)
+        .count();
+    if open_count > 1 {
+        return Err(format!(
+            "multiple open PRs found for branch {branch}; close duplicates before retrying"
+        ));
+    }
+    if open_count == 1 {
+        let index = candidates
+            .iter()
+            .position(|pr| pr.state == PrState::Open)
+            .ok_or_else(|| format!("failed to select open PR for branch {branch}"))?;
+        return Ok(candidates.swap_remove(index).into());
+    }
+
+    candidates
+        .into_iter()
+        .next()
+        .map(Into::into)
+        .ok_or_else(|| format!("no PR found for branch {branch}; create a PR first"))
 }
 
 fn fetch_children_for_base(branch: &str) -> Result<Vec<PullRequest>, String> {
@@ -409,7 +434,10 @@ pub fn build_linear_stack(
 
 #[cfg(test)]
 mod tests {
-    use super::{build_linear_stack, stack_pr_body, PrState, PullRequest};
+    use super::{
+        build_linear_stack, select_pr_for_head, stack_pr_body, PrState, PullRequest,
+        PullRequestCandidate,
+    };
 
     fn pr(number: u64, head: &str, base: &str) -> PullRequest {
         PullRequest {
@@ -417,6 +445,16 @@ mod tests {
             head_ref_name: head.to_string(),
             base_ref_name: base.to_string(),
             state: PrState::Open,
+        }
+    }
+
+    fn candidate(number: u64, head: &str, base: &str, state: PrState) -> PullRequestCandidate {
+        PullRequestCandidate {
+            number,
+            head_ref_name: head.to_string(),
+            base_ref_name: base.to_string(),
+            state,
+            is_cross_repository: false,
         }
     }
 
@@ -441,6 +479,46 @@ mod tests {
         assert_eq!(
             stack_pr_body("feature`base", "main"),
             "This pull request is part of a stack.\n\n- **Position:** Child\n- **Base:** ``feature`base``"
+        );
+    }
+
+    #[test]
+    fn structured_head_lookup_prefers_open_pr_over_history() {
+        let selected = select_pr_for_head(
+            vec![
+                candidate(100, "feature", "old-base", PrState::Merged),
+                candidate(101, "feature", "main", PrState::Open),
+            ],
+            "feature",
+        )
+        .expect("open PR should be selected");
+
+        assert_eq!(selected.number, 101);
+        assert_eq!(selected.base_ref_name, "main");
+    }
+
+    #[test]
+    fn structured_head_lookup_reports_empty_results() {
+        let error =
+            select_pr_for_head(Vec::new(), "feature").expect_err("empty lookup should fail");
+
+        assert_eq!(error, "no PR found for branch feature; create a PR first");
+    }
+
+    #[test]
+    fn structured_head_lookup_rejects_multiple_open_prs() {
+        let error = select_pr_for_head(
+            vec![
+                candidate(100, "feature", "main", PrState::Open),
+                candidate(101, "feature", "release", PrState::Open),
+            ],
+            "feature",
+        )
+        .expect_err("ambiguous lookup should fail");
+
+        assert_eq!(
+            error,
+            "multiple open PRs found for branch feature; close duplicates before retrying"
         );
     }
 

--- a/tests/harness/mod.rs
+++ b/tests/harness/mod.rs
@@ -431,6 +431,10 @@ if [[ "${1:-}" == "pr" && "${2:-}" == "list" ]]; then
   if [[ -n "${STCK_TEST_LOG:-}" ]]; then
     echo "$*" >> "${STCK_TEST_LOG}"
   fi
+  if [[ "${STCK_TEST_PR_VIEW_ERROR:-0}" == "1" ]]; then
+    echo "network unavailable" >&2
+    exit 1
+  fi
   if [[ "${STCK_TEST_PR_LIST_FAIL:-0}" == "1" ]]; then
     echo "failed to list pull requests" >&2
     exit 1
@@ -453,6 +457,11 @@ if [[ "${1:-}" == "pr" && "${2:-}" == "list" ]]; then
       pr_list_head="${!next}"
     fi
   done
+
+  if [[ -n "${STCK_TEST_PR_LIST_FAIL_HEAD:-}" && "${pr_list_head}" == "${STCK_TEST_PR_LIST_FAIL_HEAD}" ]]; then
+    echo "failed to list pull requests" >&2
+    exit 1
+  fi
 
   if [[ -n "${pr_list_base}" ]]; then
     if [[ "${STCK_TEST_NON_LINEAR:-0}" == "1" && "${pr_list_base}" == "feature-branch" ]]; then
@@ -480,12 +489,58 @@ if [[ "${1:-}" == "pr" && "${2:-}" == "list" ]]; then
     exit 0
   fi
 
-  if [[ -n "${pr_list_head}" && "${pr_list_state}" == "open" ]]; then
-    if [[ -n "${STCK_TEST_OPEN_PRS_JSON:-}" ]]; then
-      echo "${STCK_TEST_OPEN_PRS_JSON}"
-    else
-      echo '[]'
+  if [[ -n "${pr_list_head}" ]]; then
+    if [[ "${pr_list_state}" == "open" ]]; then
+      if [[ "${STCK_TEST_HAS_CURRENT_PR:-0}" == "1" && "${pr_list_head}" == "feature-branch" ]]; then
+        echo '[{"headRefName":"feature-branch","isCrossRepository":false}]'
+      elif [[ -n "${STCK_TEST_OPEN_PRS_JSON:-}" ]]; then
+        echo "${STCK_TEST_OPEN_PRS_JSON}"
+      else
+        echo '[]'
+      fi
+      exit 0
     fi
+
+    if [[ "${STCK_TEST_MISSING_CURRENT_PR:-0}" == "1" && "${pr_list_head}" == "feature-branch" ]]; then
+      echo '[]'
+      exit 0
+    fi
+
+    if [[ -n "${STCK_TEST_FEATURE_BRANCH_BASE:-}" && "${pr_list_head}" == "feature-branch" ]]; then
+      echo "[{\"number\":101,\"headRefName\":\"feature-branch\",\"baseRefName\":\"${STCK_TEST_FEATURE_BRANCH_BASE}\",\"state\":\"OPEN\",\"isCrossRepository\":false}]"
+      exit 0
+    fi
+
+    if [[ -n "${STCK_TEST_FEATURE_CHILD_BASE:-}" && "${pr_list_head}" == "feature-child" ]]; then
+      echo "[{\"number\":102,\"headRefName\":\"feature-child\",\"baseRefName\":\"${STCK_TEST_FEATURE_CHILD_BASE}\",\"state\":\"OPEN\",\"isCrossRepository\":false}]"
+      exit 0
+    fi
+
+    if [[ "${STCK_TEST_NON_LINEAR:-0}" == "1" ]]; then
+      case "${pr_list_head}" in
+        feature-base) echo '[{"number":100,"headRefName":"feature-base","baseRefName":"main","state":"MERGED","isCrossRepository":false}]' ;;
+        feature-branch) echo '[{"number":101,"headRefName":"feature-branch","baseRefName":"feature-base","state":"OPEN","isCrossRepository":false}]' ;;
+        *) echo '[]' ;;
+      esac
+      exit 0
+    fi
+
+    if [[ "${STCK_TEST_SYNC_NOOP:-0}" == "1" ]]; then
+      case "${pr_list_head}" in
+        feature-base) echo '[{"number":100,"headRefName":"feature-base","baseRefName":"main","state":"OPEN","isCrossRepository":false}]' ;;
+        feature-branch) echo '[{"number":101,"headRefName":"feature-branch","baseRefName":"feature-base","state":"OPEN","isCrossRepository":false}]' ;;
+        feature-child) echo '[{"number":102,"headRefName":"feature-child","baseRefName":"feature-branch","state":"OPEN","isCrossRepository":false}]' ;;
+        *) echo '[]' ;;
+      esac
+      exit 0
+    fi
+
+    case "${pr_list_head}" in
+      feature-base) echo '[{"number":100,"headRefName":"feature-base","baseRefName":"main","state":"MERGED","isCrossRepository":false}]' ;;
+      feature-branch) echo '[{"number":101,"headRefName":"feature-branch","baseRefName":"feature-base","state":"OPEN","isCrossRepository":false}]' ;;
+      feature-child) echo '[{"number":102,"headRefName":"feature-child","baseRefName":"feature-branch","state":"OPEN","isCrossRepository":false}]' ;;
+      *) echo '[]' ;;
+    esac
     exit 0
   fi
 
@@ -692,17 +747,19 @@ fi
 if [[ "${1:-}" == "pr" && "${2:-}" == "list" ]]; then
   base=""
   head=""
+  state="all"
   while [[ $# -gt 0 ]]; do
     case "$1" in
       --base) base="${2:-}"; shift 2 ;;
       --head) head="${2:-}"; shift 2 ;;
+      --state) state="${2:-}"; shift 2 ;;
       *) shift ;;
     esac
   done
 
   if [[ -n "${head}" ]]; then
     safe_head="${head//\//__}"
-    response="${STCK_REAL_GH_RESPONSES}/pr-list-head-${safe_head}.json"
+    response="${STCK_REAL_GH_RESPONSES}/pr-list-head-${state}-${safe_head}.json"
   elif [[ -n "${base}" ]]; then
     safe_base="${base//\//__}"
     response="${STCK_REAL_GH_RESPONSES}/pr-list-base-${safe_base}.json"
@@ -866,6 +923,20 @@ exit 1
             json,
         )
         .expect("gh PR response should be written");
+        fs::write(
+            self.gh_responses
+                .join(format!("pr-list-head-all-{branch}.json")),
+            format!("[{json}]"),
+        )
+        .expect("gh all-state head response should be written");
+        if json.contains(r#""state":"OPEN""#) {
+            fs::write(
+                self.gh_responses
+                    .join(format!("pr-list-head-open-{branch}.json")),
+                format!("[{json}]"),
+            )
+            .expect("gh open-state head response should be written");
+        }
     }
 
     pub fn write_children_response(&self, base: &str, json: &str) {
@@ -880,7 +951,8 @@ exit 1
     pub fn write_open_pr_head_response(&self, head: &str, json: &str) {
         let head = head.replace('/', "__");
         fs::write(
-            self.gh_responses.join(format!("pr-list-head-{head}.json")),
+            self.gh_responses
+                .join(format!("pr-list-head-open-{head}.json")),
             json,
         )
         .expect("gh head response should be written");

--- a/tests/new.rs
+++ b/tests/new.rs
@@ -141,11 +141,11 @@ fn new_prefers_remote_parent_when_local_parent_has_drifted() {
 #[test]
 fn new_fails_when_targeted_parent_query_errors() {
     let (_temp, mut cmd) = stck_cmd_with_stubbed_tools();
-    cmd.env("STCK_TEST_PR_LIST_FAIL", "1");
+    cmd.env("STCK_TEST_PR_LIST_FAIL_HEAD", "feature-base");
     cmd.args(["new", "feature-next"]);
 
     cmd.assert().code(1).stderr(predicate::str::contains(
-        "error: could not auto-detect stack parent for feature-branch: failed to query open pull request for branch feature-base; stderr: failed to list pull requests; retry or pass `--base <branch>` explicitly",
+        "error: could not auto-detect stack parent for feature-branch: failed to check PR for branch feature-base; ensure `gh auth status` succeeds and retry; stderr: failed to list pull requests; retry or pass `--base <branch>` explicitly",
     ));
 }
 

--- a/tests/real_git.rs
+++ b/tests/real_git.rs
@@ -54,7 +54,9 @@ fn submit_pushes_a_real_branch_before_creating_its_pr() {
         repo.remote_sha("feature-submit")
     );
     let gh_log = repo.gh_log();
-    assert!(gh_log.contains("pr view feature-submit --json number"));
+    assert!(gh_log.contains(
+        "pr list --head feature-submit --state open --limit 100 --json headRefName,isCrossRepository"
+    ));
     assert!(gh_log.contains("pr create --base main --head feature-submit"));
     assert!(gh_log.contains(
         "This pull request is part of a stack.\n\n- **Position:** Root\n- **Base:** `main`"
@@ -90,7 +92,7 @@ fn submit_discovers_a_remote_parent_without_its_local_branch() {
 
     let gh_log = repo.gh_log();
     assert!(gh_log.contains(
-        "pr list --head feature-base --state open --limit 1 --json headRefName,isCrossRepository"
+        "pr list --head feature-base --state open --limit 100 --json headRefName,isCrossRepository"
     ));
     assert!(
         !gh_log.contains("pr list --state open --limit 100"),

--- a/tests/submit.rs
+++ b/tests/submit.rs
@@ -68,11 +68,11 @@ fn submit_falls_back_to_default_when_no_parent_pr() {
 #[test]
 fn submit_fails_when_targeted_parent_query_errors() {
     let (_temp, mut cmd) = stck_cmd_with_stubbed_tools();
-    cmd.env("STCK_TEST_PR_LIST_FAIL", "1");
+    cmd.env("STCK_TEST_PR_LIST_FAIL_HEAD", "feature-base");
     cmd.arg("submit");
 
     cmd.assert().code(1).stderr(predicate::str::contains(
-        "error: could not auto-detect stack parent for feature-branch: failed to query open pull request for branch feature-base; stderr: failed to list pull requests; retry or pass `--base <branch>` explicitly",
+        "error: could not auto-detect stack parent for feature-branch: failed to check PR for branch feature-base; ensure `gh auth status` succeeds and retry; stderr: failed to list pull requests; retry or pass `--base <branch>` explicitly",
     ));
 }
 
@@ -197,7 +197,7 @@ fn submit_discovers_parent_base_for_stacked_branch() {
 
     let log = fs::read_to_string(&log_path).expect("submit log should exist");
     assert!(log.contains(
-        "pr list --head feature-base --state open --limit 1 --json headRefName,isCrossRepository"
+        "pr list --head feature-base --state open --limit 100 --json headRefName,isCrossRepository"
     ));
     assert!(
         !log.contains("pr list --state open --limit 100"),


### PR DESCRIPTION
## Summary

Replace human-readable `gh pr view` error parsing with structured pull-request queries.

Open-PR presence now treats an empty JSON list as the normal not-found case, while stack discovery selects the current open PR over historical entries and rejects ambiguous duplicate open PRs. GitHub command failures continue to surface as actionable errors.

Stack position: 7 of 10. Base: `target-parent-discovery`. Parent PR: #55.

## Changelist

- `src/github.rs` — use structured head queries for PR presence and stack discovery
- `src/commands.rs` — reuse the structured open-PR lookup during parent discovery
- `tests/harness/mod.rs` — model state-specific JSON list responses in both test harnesses
- `tests/new.rs` and `tests/submit.rs` — verify targeted lookup failures and command arguments
- `tests/real_git.rs` — assert the structured GitHub query path end to end