### PR TITLE
Align help and documentation

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -60,7 +60,7 @@ stck new feature-b
   - current branch (normal stacked flow), or
   - default branch when starting a new stack from default branch.
 
-If the new branch has no commits beyond its base, `stck` does not create an empty PR and prints an explicit follow-up `gh pr create ...` command to run after adding commits.
+If the new branch has no commits beyond its base, `stck` does not create an empty PR and tells you to add commits, then run `stck submit --base <parent>`.
 
 ### 2b. Submit PR for current branch
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -26,7 +26,7 @@ enum Commands {
     },
     /// Create a PR for the current branch if missing.
     Submit {
-        /// Base branch for the PR (defaults to repository default branch).
+        /// Base branch for the PR (auto-detects the stack parent when omitted).
         #[arg(long)]
         base: Option<String>,
     },

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -18,6 +18,19 @@ fn help_lists_all_commands() {
 }
 
 #[test]
+fn submit_help_describes_parent_auto_discovery() {
+    let mut cmd = stck_cmd();
+    cmd.args(["submit", "--help"]);
+
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "Base branch for the PR (auto-detects the stack parent when omitted)",
+        ))
+        .stdout(predicate::str::contains("defaults to repository default branch").not());
+}
+
+#[test]
 fn version_prints_package_version() {
     let mut cmd = stck_cmd();
     cmd.arg("--version");


### PR DESCRIPTION
## Summary

Bring the remaining user-facing help and usage text back in line with shipped command behavior.

`submit --base` now explains that omission triggers stack-parent discovery, and the no-commit `new` guidance points to `stck submit --base <parent>` instead of an obsolete raw `gh pr create` follow-up.

Stack position: 9 of 10. Base: `test-sync-recovery`. Parent PR: #57.

## Changelist

- `src/cli.rs` — describe `submit --base` auto-discovery accurately
- `USAGE.md` — document the actual no-commit follow-up command
- `tests/cli.rs` — lock the corrected submit help text with a CLI regression test