### PR TITLE
Document sync recovery

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,3 +28,10 @@ that version and the current stable toolchain.
 - Document what an item does, important invariants or assumptions, and notable error behavior when that is not obvious from the code alone.
 - Use inline `//` comments sparingly and only for non-obvious logic or workflow invariants.
 - Prefer reducing visibility over documenting accidental public API surface.
+
+## Behavioral Contracts
+
+The tracked [sync recovery contract](./docs/sync-recovery.md) is normative.
+Changes to sync state or recovery must preserve its fail-closed guarantees or
+update the contract and corresponding stubbed and real-Git tests in the same
+pull request.

--- a/USAGE.md
+++ b/USAGE.md
@@ -103,6 +103,11 @@ stck sync --continue
 stck sync --reset
 ```
 
+Finish or abort the native Git rebase before invoking the corresponding `stck`
+recovery command. A plain `stck sync` never skips a recorded failed step.
+See [`docs/sync-recovery.md`](./docs/sync-recovery.md) for the complete state
+and recovery contract.
+
 ### 4. Push rewritten branches and retarget PR bases
 
 ```bash
@@ -134,4 +139,4 @@ stck push
 
 - `stck` currently assumes a linear stack and fails fast for non-linear graphs.
 - Parent auto-discovery for `new`/`submit` checks fetched `origin` branches and queries GitHub only for ancestor candidates, avoiding a repository-wide PR result limit.
-- If a rebase conflict happens during `sync`, resolve conflicts with normal Git workflow, then continue and rerun `stck sync` as needed.
+- If a rebase conflict happens during `sync`, finish it with `git rebase --continue`, then run `stck sync --continue`; to start over, abort the Git rebase first and run `stck sync --reset`.

--- a/docs/sync-recovery.md
+++ b/docs/sync-recovery.md
@@ -1,0 +1,72 @@
+# Sync Recovery Contract
+
+`stck sync` restacks local branches only. It may fetch and read GitHub metadata,
+but it does not push branches or change pull request bases.
+
+This document is the authoritative recovery contract for interrupted sync
+operations. Older planning notes that describe automatic continuation from a
+plain `stck sync` rerun are historical.
+
+## Fresh sync
+
+A fresh `stck sync`:
+
+1. refuses to start while a native Git rebase is already in progress,
+2. fetches `origin` and computes the current stack plan,
+3. saves that plan under `.git/stck/` before running its first rebase,
+4. records progress after every completed step.
+
+If a rebase fails, `stck` records the failed step and the branch head at which
+it failed. That state remains available until the operation is continued,
+reset, or completed.
+
+## Continue after resolving a conflict
+
+Finish the native Git rebase first:
+
+```bash
+# resolve the conflicted files
+git add <resolved-files>
+git rebase --continue
+
+# repeat resolve/add/continue until Git finishes, then:
+stck sync --continue
+```
+
+`stck sync --continue` is deliberately strict. It requires:
+
+- saved sync state,
+- no native rebase still in progress,
+- evidence that the failed branch head changed after the completed rebase.
+
+Only then does it mark the failed step complete and continue with later stack
+branches. A plain `stck sync` does not infer this transition or skip the failed
+step; it directs the user to choose `--continue` or `--reset` explicitly.
+
+## Abort and recompute
+
+To discard the interrupted attempt:
+
+```bash
+git rebase --abort
+stck sync --reset
+```
+
+`stck sync --reset` clears the saved sync operation and computes a new plan
+from current Git and GitHub state. It does not abort an active native rebase,
+so `git rebase --abort` must finish first.
+
+## State and command boundaries
+
+- In-flight sync progress lives in `.git/stck/last-plan.json`.
+- `stck push` is blocked while sync state remains unresolved.
+- A successful sync clears in-flight state and saves a stack-scoped retarget
+  plan in `.git/stck/last-sync-plan.json`.
+- `stck push` reuses that cached plan only when its repository and exact stack
+  metadata still match.
+- A no-op sync clears any stale cached retarget plan.
+- Sync recovery never pushes branches or mutates pull requests; `stck push`
+  remains the explicit remote mutation step.
+
+Do not edit files under `.git/stck/` manually. Use the recovery commands above
+so state validation and cleanup remain intact.


### PR DESCRIPTION
## Summary

Record the shipped sync recovery behavior as a durable, tracked contract for users and contributors.

The contract separates native Git rebase recovery from `stck` state recovery, defines the strict requirements for `sync --continue`, explains abort/reset behavior, and documents state cleanup plus the local-only sync boundary. It explicitly treats older automatic plain-rerun behavior as historical.

Stack position: 10 of 10. Base: `align-help-and-docs`. Parent PR: #58.

## Changelist

- `docs/sync-recovery.md` — define fresh sync, continue, reset, state, and command-boundary guarantees
- `USAGE.md` — link the contract and replace ambiguous conflict guidance with exact commands
- `CONTRIBUTING.md` — require sync-state changes to preserve or deliberately update the normative contract and tests